### PR TITLE
Format Telegram reply amounts with two decimals

### DIFF
--- a/backend_new/app/services/telegram_ingestion.py
+++ b/backend_new/app/services/telegram_ingestion.py
@@ -95,10 +95,11 @@ async def _send_create_reply(
     transaction: TransactionResponse,
 ) -> None:
     note = transaction.note or ""
+    formatted_amount = f"{transaction.amount:.2f}"
     text = (
         "Transaction was saved.\n"
         f"Date: {transaction.transactionDate.isoformat()}\n"
-        f"Amount: {transaction.amount}\n"
+        f"Amount: {formatted_amount}\n"
         f"Currency: {transaction.currency}\n"
         f"Note: {note}"
     )

--- a/backend_new/tests/test_telegram_ingestion.py
+++ b/backend_new/tests/test_telegram_ingestion.py
@@ -37,9 +37,7 @@ class _FakeContext:
     bot: _FakeBot
 
 
-def _build_update(
-    *, from_id: int, reply_to_message_id: int | None = None, edited: bool = False
-) -> Update:
+def _build_update(*, from_id: int, reply_to_message_id: int | None = None, edited: bool = False) -> Update:
     message_payload: dict[str, object] = {
         "message_id": 15,
         "date": 1758301908,
@@ -133,7 +131,9 @@ def test_telegram_ingestion_creates_transaction(monkeypatch) -> None:
     asyncio.run(handle_telegram_update(update, context))
 
     assert len(context.bot.sent_messages) == 1
-    assert "Transaction was saved." in str(context.bot.sent_messages[0]["text"])
+    sent_text = str(context.bot.sent_messages[0]["text"])
+    assert "Transaction was saved." in sent_text
+    assert "Amount: 107.68" in sent_text
 
 
 def test_telegram_ingestion_edited_message_uses_same_upsert_path(monkeypatch) -> None:
@@ -154,6 +154,8 @@ def test_telegram_ingestion_edited_message_uses_same_upsert_path(monkeypatch) ->
     asyncio.run(handle_telegram_update(update, context))
 
     assert len(context.bot.sent_messages) == 1
-    assert "Transaction was saved." in str(context.bot.sent_messages[0]["text"])
+    sent_text = str(context.bot.sent_messages[0]["text"])
+    assert "Transaction was saved." in sent_text
+    assert "Amount: 107.68" in sent_text
     assert len(upsert_calls) == 1
     assert upsert_calls[0]["message_id"] == "15"

--- a/docs/tasklist.md
+++ b/docs/tasklist.md
@@ -16,6 +16,7 @@ Legend: Pending | In Progress | Complete | Blocked
 | Query Efficiency | SQL-based count optimization for transaction listings | Complete | 2026-02-22 | `totalCount` moved to DB aggregate query |
 | Auth Gate Activation | Local dual-mode integration run for production auth checks | Complete | 2026-02-22 | Dev+prod auth scenarios validated in one flow |
 | Telegram Flow Migration | `SavingTransactions` flow moved from n8n to FastAPI + PTB webhook ingestion | Complete | 2026-03-20 | Added `/api/telegram/webhook`, PTB runtime, OpenAI parsing, and Telegram ingestion tests |
+| Telegram Reply Formatting | Telegram save confirmation now renders amounts with two decimal places | Complete | 2026-03-23 | Normalized reply text to fixed `.2f` amount formatting for saved transactions |
 
 ## Working Rules
 


### PR DESCRIPTION
### Motivation
- Ensure Telegram confirmation replies render monetary amounts with exactly two digits after the decimal so values like `-70.0` appear as `-70.00` for clearer, consistent user-facing output.

### Description
- Format the saved-transaction reply amount by using `formatted_amount = f"{transaction.amount:.2f}"` in `backend_new/app/services/telegram_ingestion.py`.
- Replace the unformatted `f"Amount: {transaction.amount}\n"` with the formatted variable in the reply text construction.
- Update `backend_new/tests/test_telegram_ingestion.py` to assert the formatted amount appears in the sent reply for both normal and edited-message paths.
- Record the change in `docs/tasklist.md` as a completed task item.

### Testing
- Ran code style and formatting with `uv run ruff format` and `uv run ruff check` which passed for the modified files.
- Ran static typing checks with `uv run mypy` in `backend_new` which passed for the touched modules.
- Executed the targeted tests with `uv run pytest -q backend_new/tests/test_telegram_ingestion.py` and all tests passed (4/4).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17446c9108320a4d34ec110fe8b0b)