### PR TITLE
feat: Implement two-step LLM category suggestion for Telegram ingestion

### DIFF
--- a/backend_new/GUARDRAILS.md
+++ b/backend_new/GUARDRAILS.md
@@ -72,3 +72,8 @@ Keep entries short, actionable, and repository-specific.
 - Takeaway: sandboxed `uv` runs can panic or fail with cache/system permission errors, causing false infrastructure failures.
 - Exploration: ruled out app defects by rerunning the same orchestration with `UV_CACHE_DIR=./.uv-cache` and escalated execution; tests then passed.
 - Prevention rule: default to orchestrated runs with `UV_CACHE_DIR=./.uv-cache`; escalate only when failure class is `sandbox/permission`.
+
+### 2026-04-03 - Async Loop Consistency in Piccolo E2E
+- Takeaway: running Piccolo pool operations across multiple `asyncio.run(...)` calls causes cross-loop failures (`Future attached to a different loop` / `another operation is in progress`).
+- Exploration: ruled out query logic by reproducing failures only when pool start/query/close spanned different event loops; stable behavior returned after executing the full scenario in one coroutine.
+- Prevention rule: when tests use `engine.start_connection_pool()`, run setup, business calls, and teardown in a single async coroutine with one `asyncio.run(...)` entrypoint.

--- a/backend_new/app/api/routes/telegram.py
+++ b/backend_new/app/api/routes/telegram.py
@@ -27,9 +27,7 @@ def _is_webhook_secret_valid(received_secret: str | None) -> bool:
 @router.post("/webhook", response_class=PlainTextResponse)
 async def telegram_webhook(
     request: Request,
-    x_telegram_bot_api_secret_token: str | None = Header(
-        default=None, alias="X-Telegram-Bot-Api-Secret-Token"
-    ),
+    x_telegram_bot_api_secret_token: str | None = Header(default=None, alias="X-Telegram-Bot-Api-Secret-Token"),
 ) -> PlainTextResponse:
     if not _is_webhook_secret_valid(x_telegram_bot_api_secret_token):
         raise HTTPException(
@@ -46,14 +44,10 @@ async def telegram_webhook(
 
     body = await request.json()
     if not isinstance(body, Mapping):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid update payload"
-        )
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid update payload")
     parsed_update = Update.de_json(dict(body), runtime.application.bot)
     if parsed_update is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid update payload"
-        )
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid update payload")
 
     await runtime.application.update_queue.put(parsed_update)
     return PlainTextResponse("OK")

--- a/backend_new/app/core/config.py
+++ b/backend_new/app/core/config.py
@@ -9,9 +9,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
-    environment: Literal["Development", "Production", "Test"] = Field(
-        default="Development", alias="ENVIRONMENT"
-    )
+    environment: Literal["Development", "Production", "Test"] = Field(default="Development", alias="ENVIRONMENT")
     api_host: str = Field(default="0.0.0.0", alias="API_HOST")
     api_port: int = Field(default=8000, alias="API_PORT")
     cors_allow_origins: str = Field(default="http://localhost:3000", alias="CORS_ALLOW_ORIGINS")

--- a/backend_new/app/db/queries.py
+++ b/backend_new/app/db/queries.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal
 from typing import cast
@@ -8,7 +9,9 @@ from typing import cast
 from piccolo.columns.base import Column
 from piccolo.columns.column_types import Varchar
 from piccolo.columns.combination import WhereRaw
+from piccolo.query.functions.aggregate import Max
 from piccolo.query.functions.type_conversion import Cast
+from piccolo.query.mixins import OrderByRaw
 
 from app.core.config import get_settings
 from app.models import Category, Transaction
@@ -20,6 +23,14 @@ from app.schemas.responses import (
 from app.schemas.transactions import CreateTransactionRequest, UpdateTransactionRequest
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SimilarCategoryExample:
+    note: str
+    amount: Decimal
+    category_id: int
+    category_name: str
 
 
 def _to_utc(dt: datetime) -> datetime:
@@ -120,9 +131,7 @@ async def fetch_transactions(
         count_query = count_query.where(Transaction.transaction_date >= from_start)
 
     if to_date is not None:
-        to_end_exclusive = datetime.combine(
-            to_date + timedelta(days=1), time.min, tzinfo=business_tz
-        )
+        to_end_exclusive = datetime.combine(to_date + timedelta(days=1), time.min, tzinfo=business_tz)
         to_end_exclusive_utc = to_end_exclusive.astimezone(UTC)
         query = query.where(Transaction.transaction_date < to_end_exclusive_utc)
         count_query = count_query.where(Transaction.transaction_date < to_end_exclusive_utc)
@@ -150,8 +159,7 @@ async def fetch_transactions(
     if text:
         text_pattern = f"%{text}%"
         category_ids = [
-            int(category.id)
-            for category in await Category.objects().where(Category.name.ilike(text_pattern)).run()
+            int(category.id) for category in await Category.objects().where(Category.name.ilike(text_pattern)).run()
         ]
         text_condition = (
             Transaction.note.ilike(text_pattern)
@@ -164,19 +172,12 @@ async def fetch_transactions(
         count_query = count_query.where(text_condition)
 
     total_count = int(await count_query.run())
-    paged = (
-        await query.order_by(Transaction.transaction_date, ascending=False)
-        .offset(skip)
-        .limit(take)
-        .run()
-    )
+    paged = await query.order_by(Transaction.transaction_date, ascending=False).offset(skip).limit(take).run()
     category_map = await _category_lookup()
     data = [
         _map_transaction(
             transaction,
-            category_map.get(int(transaction.category_id))
-            if transaction.category_id is not None
-            else None,
+            category_map.get(int(transaction.category_id)) if transaction.category_id is not None else None,
         )
         for transaction in paged
     ]
@@ -190,9 +191,7 @@ async def fetch_transactions(
     )
 
 
-async def create_transaction(
-    *, user_id: int, payload: CreateTransactionRequest
-) -> TransactionResponse:
+async def create_transaction(*, user_id: int, payload: CreateTransactionRequest) -> TransactionResponse:
     transaction = Transaction(
         user_id=user_id,
         transaction_date=_to_utc(payload.transaction_date),
@@ -233,9 +232,7 @@ async def update_transaction(
 
     category = None
     if transaction.category_id is not None:
-        category = (
-            await Category.objects().where(Category.id == transaction.category_id).first().run()
-        )
+        category = await Category.objects().where(Category.id == transaction.category_id).first().run()
 
     return _map_transaction(transaction, category)
 
@@ -326,3 +323,134 @@ async def upsert_transaction_by_message_id(
 
     row = rows[0]
     return _map_transaction_row(row)
+
+
+async def fetch_category_name_by_id(*, category_id: int) -> str | None:
+    category = await Category.objects().where(Category.id == category_id).first().run()
+    if category is None:
+        return None
+    return category.name
+
+
+async def fetch_transaction_by_id_for_user(
+    *,
+    user_id: int,
+    transaction_id: int,
+) -> TransactionResponse | None:
+    transaction = (
+        await Transaction.objects()
+        .where((Transaction.id == transaction_id) & (Transaction.user_id == user_id))
+        .first()
+        .run()
+    )
+    if transaction is None:
+        return None
+    category = None
+    if transaction.category_id is not None:
+        category = await Category.objects().where(Category.id == transaction.category_id).first().run()
+    return _map_transaction(transaction, category)
+
+
+async def update_transaction_category_for_user(
+    *,
+    user_id: int,
+    transaction_id: int,
+    category_id: int | None,
+) -> TransactionResponse | None:
+    transaction = (
+        await Transaction.objects()
+        .where((Transaction.id == transaction_id) & (Transaction.user_id == user_id))
+        .first()
+        .run()
+    )
+    if transaction is None:
+        return None
+
+    transaction.category_id = category_id
+    await transaction.save()
+    category = None
+    if category_id is not None:
+        category = await Category.objects().where(Category.id == category_id).first().run()
+    return _map_transaction(transaction, category)
+
+
+async def fetch_similar_category_examples(
+    *,
+    user_id: int,
+    note_prefix: str,
+    exclude_transaction_id: int,
+    limit: int = 3,
+) -> list[SimilarCategoryExample]:
+    if not note_prefix or limit <= 0:
+        return []
+
+    normalized_prefix = note_prefix.strip()
+    if not normalized_prefix:
+        return []
+
+    pattern = f"{normalized_prefix}%"
+    base_condition = (
+        (Transaction.user_id == user_id)
+        & Transaction.category_id.is_not_null()
+        & (Transaction.id != exclude_transaction_id)
+        & Transaction.note.ilike(pattern)
+    )
+    ranked_category_rows = (
+        await Transaction.select(
+            Transaction.category_id,
+            Max(Transaction.transaction_date, alias="latest_transaction_date"),
+        )
+        .where(base_condition)
+        .group_by(Transaction.category_id)
+        .order_by(OrderByRaw('MAX("transaction"."transaction_date")'), ascending=False)
+        .order_by(Transaction.category_id)
+        .limit(limit)
+        .run()
+    )
+    if not ranked_category_rows:
+        return []
+
+    ranked_category_ids = [
+        int(category_id)
+        for category_id in [cast(int | None, row["category_id"]) for row in ranked_category_rows]
+        if category_id is not None
+    ]
+    if not ranked_category_ids:
+        return []
+
+    category_rank = {category_id: rank for rank, category_id in enumerate(ranked_category_ids)}
+    rows = (
+        await Transaction.select(
+            Transaction.note,
+            Transaction.amount,
+            Transaction.category_id,
+        )
+        .where(base_condition & Transaction.category_id.is_in(ranked_category_ids))
+        .distinct(on=[Transaction.category_id])
+        .order_by(Transaction.category_id)
+        .order_by(Transaction.transaction_date, ascending=False)
+        .run()
+    )
+    if not rows:
+        return []
+
+    rows.sort(key=lambda row: category_rank.get(int(cast(int, row["category_id"])), len(category_rank)))
+
+    category_map = await _category_lookup()
+    examples: list[SimilarCategoryExample] = []
+    for row in rows:
+        category_id = cast(int | None, row["category_id"])
+        if category_id is None:
+            continue
+        category = category_map.get(category_id)
+        if category is None:
+            continue
+        examples.append(
+            SimilarCategoryExample(
+                note=cast(str | None, row["note"]) or "",
+                amount=cast(Decimal, row["amount"]),
+                category_id=category_id,
+                category_name=category.name,
+            )
+        )
+    return examples

--- a/backend_new/app/main.py
+++ b/backend_new/app/main.py
@@ -28,9 +28,7 @@ async def lifespan(application: FastAPI) -> AsyncIterator[None]:
 
 configure_logging()
 settings = get_settings()
-allowed_origins = [
-    origin.strip() for origin in settings.cors_allow_origins.split(",") if origin.strip()
-]
+allowed_origins = [origin.strip() for origin in settings.cors_allow_origins.split(",") if origin.strip()]
 
 app = FastAPI(title="Money Track API (Python)", version="0.1.0", lifespan=lifespan)
 app.add_middleware(

--- a/backend_new/app/services/category_suggestion.py
+++ b/backend_new/app/services/category_suggestion.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from functools import lru_cache
+
+from openai import APIError, APIStatusError, AsyncOpenAI
+from pydantic import BaseModel, Field
+
+from app.core.config import get_settings
+from app.db.queries import (
+    fetch_categories,
+    fetch_similar_category_examples,
+    update_transaction_category_for_user,
+)
+from app.schemas.responses import CategoryResponse, TransactionResponse
+
+logger = logging.getLogger(__name__)
+
+CATEGORY_SUGGESTION_SYSTEM_PROMPT = "\n".join(
+    [
+        "You classify one financial transaction into existing categories.",
+        "Choose only category IDs from the provided list.",
+        "Use historical examples as a strong signal, especially note-prefix matches.",
+        "If evidence is weak, you may abstain by leaving top_category_id null.",
+        "Return valid JSON matching the schema only.",
+    ]
+)
+
+
+@dataclass(frozen=True)
+class CategoryActionOption:
+    category_id: int
+    category_name: str
+
+
+@dataclass(frozen=True)
+class CategorySuggestionResult:
+    applied_category_id: int | None
+    applied_category_name: str | None
+    top3_options: list[CategoryActionOption]
+
+
+class CategorySuggestionLlmOutput(BaseModel):
+    top_category_id: int | None = Field(default=None)
+    alternatives: list[int] = Field(default_factory=list)
+    confidence: float | None = Field(default=None)
+    reason: str | None = Field(default=None)
+
+
+@lru_cache(maxsize=1)
+def _get_openai_client() -> AsyncOpenAI:
+    settings = get_settings()
+    return AsyncOpenAI(
+        api_key=settings.openai_api_key,
+        timeout=20.0,
+    )
+
+
+def _dedup_keep_order(values: list[int]) -> list[int]:
+    deduped: list[int] = []
+    seen: set[int] = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
+
+
+def _build_top3_ids(
+    *,
+    seed_ids: list[int],
+    fallback_ids: list[int],
+) -> list[int]:
+    merged = _dedup_keep_order(seed_ids + fallback_ids)
+    return merged[:3]
+
+
+def _build_fallback_priority(
+    *,
+    amount: float | None,
+    categories: list[CategoryResponse],
+) -> list[int]:
+    ordered_category_ids = [category.id for category in categories]
+    if amount is None or amount == 0:
+        return ordered_category_ids
+
+    desired_type = "income" if amount > 0 else "expense"
+    sign_matched_ids = [category.id for category in categories if category.type.strip().lower() == desired_type]
+    if not sign_matched_ids:
+        return ordered_category_ids
+
+    return _dedup_keep_order(sign_matched_ids + ordered_category_ids)
+
+
+async def _call_category_suggestion_llm(
+    *,
+    note: str | None,
+    sms_text: str | None,
+    amount: float,
+    currency: str,
+    examples: list[dict[str, object]],
+    categories: list[dict[str, object]],
+) -> CategorySuggestionLlmOutput | None:
+    settings = get_settings()
+    if not settings.openai_api_key:
+        logger.error("OpenAI API key is not configured for category suggestion")
+        return None
+
+    payload = {
+        "transaction": {
+            "note": note or "",
+            "sms_text": sms_text or "",
+            "amount": amount,
+            "currency": currency,
+        },
+        "examples": examples,
+        "categories": categories,
+    }
+    client = _get_openai_client()
+    try:
+        parsed_response = await client.responses.parse(
+            model=settings.openai_model,
+            temperature=0,
+            instructions=CATEGORY_SUGGESTION_SYSTEM_PROMPT,
+            input=json.dumps(payload, ensure_ascii=True),
+            text_format=CategorySuggestionLlmOutput,
+        )
+    except APIStatusError as exc:
+        logger.error(
+            "Category suggestion OpenAI request failed with status %s: %s (%s)",
+            exc.status_code,
+            exc.response.text if exc.response is not None else "<no-body>",
+            exc,
+            exc_info=True,
+        )
+        return None
+    except APIError as exc:
+        logger.error(
+            "Failed to classify category via OpenAI SDK: %s",
+            exc,
+            exc_info=True,
+        )
+        return None
+
+    parsed = parsed_response.output_parsed
+    if not isinstance(parsed, CategorySuggestionLlmOutput):
+        logger.error(
+            "Category suggestion parser returned unexpected output type: %s",
+            type(parsed).__name__,
+        )
+        return None
+    return parsed
+
+
+async def build_default_category_actions(
+    *,
+    preferred_category_id: int | None = None,
+    amount: float | None = None,
+) -> CategorySuggestionResult:
+    categories = await fetch_categories()
+    category_map = {category.id: category for category in categories}
+    fallback_ids = _build_fallback_priority(amount=amount, categories=categories)
+
+    seed_ids: list[int] = []
+    if preferred_category_id is not None and preferred_category_id in category_map:
+        seed_ids.append(preferred_category_id)
+    top3_ids = _build_top3_ids(seed_ids=seed_ids, fallback_ids=fallback_ids)
+
+    top3_options = [
+        CategoryActionOption(
+            category_id=category_id,
+            category_name=category_map[category_id].name,
+        )
+        for category_id in top3_ids
+    ]
+    applied_category_name = (
+        category_map[preferred_category_id].name
+        if preferred_category_id is not None and preferred_category_id in category_map
+        else None
+    )
+    return CategorySuggestionResult(
+        applied_category_id=preferred_category_id,
+        applied_category_name=applied_category_name,
+        top3_options=top3_options,
+    )
+
+
+async def suggest_and_apply_transaction_category(
+    *,
+    user_id: int,
+    transaction: TransactionResponse,
+) -> CategorySuggestionResult:
+    try:
+        categories = await fetch_categories()
+        if not categories:
+            logger.info(
+                "event=category_suggestion_skipped_no_candidates user_id=%s transaction_id=%s reason=no_categories",
+                user_id,
+                transaction.id,
+            )
+            return CategorySuggestionResult(
+                applied_category_id=transaction.categoryId,
+                applied_category_name=None,
+                top3_options=[],
+            )
+
+        category_map = {category.id: category for category in categories}
+        fallback_ids = _build_fallback_priority(amount=transaction.amount, categories=categories)
+
+        note_prefix = (transaction.note or "").strip()
+        similar_examples = await fetch_similar_category_examples(
+            user_id=user_id,
+            note_prefix=note_prefix,
+            exclude_transaction_id=transaction.id,
+            limit=3,
+        )
+
+        logger.info(
+            "event=category_suggestion_attempted user_id=%s transaction_id=%s examples=%s categories=%s",
+            user_id,
+            transaction.id,
+            len(similar_examples),
+            len(categories),
+        )
+
+        llm_output = await _call_category_suggestion_llm(
+            note=transaction.note,
+            sms_text=transaction.smsText,
+            amount=transaction.amount,
+            currency=transaction.currency,
+            examples=[
+                {
+                    "note": example.note,
+                    "amount": float(example.amount),
+                    "category_id": example.category_id,
+                    "category_name": example.category_name,
+                }
+                for example in similar_examples
+            ],
+            categories=[
+                {
+                    "id": category.id,
+                    "name": category.name,
+                    "type": category.type,
+                }
+                for category in categories
+            ],
+        )
+
+        valid_category_ids = set(category_map.keys())
+        llm_seed_ids: list[int] = []
+        top_category_id: int | None = None
+        if llm_output is not None:
+            if llm_output.top_category_id is not None and llm_output.top_category_id in valid_category_ids:
+                top_category_id = llm_output.top_category_id
+                llm_seed_ids.append(top_category_id)
+            llm_seed_ids.extend(
+                [category_id for category_id in llm_output.alternatives if category_id in valid_category_ids]
+            )
+        llm_seed_ids = _dedup_keep_order(llm_seed_ids)
+
+        if not llm_seed_ids:
+            logger.info(
+                (
+                    "event=category_suggestion_skipped_no_candidates "
+                    "user_id=%s transaction_id=%s reason=no_valid_llm_suggestions"
+                ),
+                user_id,
+                transaction.id,
+            )
+
+        top3_ids = _build_top3_ids(seed_ids=llm_seed_ids, fallback_ids=fallback_ids)
+        top3_options = [
+            CategoryActionOption(
+                category_id=category_id,
+                category_name=category_map[category_id].name,
+            )
+            for category_id in top3_ids
+        ]
+
+        applied_category_id = transaction.categoryId
+        if top_category_id is not None:
+            updated = await update_transaction_category_for_user(
+                user_id=user_id,
+                transaction_id=transaction.id,
+                category_id=top_category_id,
+            )
+            if updated is not None:
+                applied_category_id = updated.categoryId
+                logger.info(
+                    "event=category_suggestion_applied user_id=%s transaction_id=%s category_id=%s",
+                    user_id,
+                    transaction.id,
+                    applied_category_id,
+                )
+
+        applied_category_name = (
+            category_map[applied_category_id].name
+            if applied_category_id is not None and applied_category_id in category_map
+            else None
+        )
+        return CategorySuggestionResult(
+            applied_category_id=applied_category_id,
+            applied_category_name=applied_category_name,
+            top3_options=top3_options,
+        )
+    except Exception as exc:
+        logger.error(
+            "event=category_suggestion_failed user_id=%s transaction_id=%s error=%s",
+            user_id,
+            transaction.id,
+            exc,
+            exc_info=True,
+        )
+        return await build_default_category_actions(
+            preferred_category_id=transaction.categoryId,
+            amount=transaction.amount,
+        )

--- a/backend_new/app/services/sms_parser.py
+++ b/backend_new/app/services/sms_parser.py
@@ -15,10 +15,7 @@ SMS_PARSER_SYSTEM_PROMPT = "\n".join(
     [
         "You are an information extraction system for financial SMS alerts.",
         "Your task is to extract only what is explicitly written in the SMS text.",
-        (
-            "If the SMS lacks any required field or if extraction is uncertain, "
-            "return an empty JSON object."
-        ),
+        ("If the SMS lacks any required field or if extraction is uncertain, return an empty JSON object."),
         "",
         "Extract the following fields:",
         (
@@ -33,10 +30,7 @@ SMS_PARSER_SYSTEM_PROMPT = "\n".join(
         ),
         "",
         "Strict Rules:",
-        (
-            "1. Never infer or assume information not explicitly present. Only return what "
-            "is clearly stated in the SMS."
-        ),
+        ("1. Never infer or assume information not explicitly present. Only return what is clearly stated in the SMS."),
         (
             "2. Always extract ONLY ONE AED amount if SMS contains more that one amount and "
             "currency. amount in AED has the highest priority."
@@ -45,10 +39,7 @@ SMS_PARSER_SYSTEM_PROMPT = "\n".join(
         "- Use a negative sign (-) for expenses like purchases, debits, payments.",
         "- Use a positive sign (+) for credits like refunds, deposits, earnings.",
         "4. If you cannot reliably extract all required fields, return an empty object: {}",
-        (
-            "5. If the SMS does not clearly match an expense or income, do not guess the "
-            "sign — return {}."
-        ),
+        ("5. If the SMS does not clearly match an expense or income, do not guess the sign — return {}."),
         "",
         "Output format (as JSON):",
         "{",
@@ -63,9 +54,7 @@ SMS_PARSER_SYSTEM_PROMPT = "\n".join(
 
 class ParsedSmsTransaction(BaseModel):
     amount: Decimal | None = Field(description="Amount of the transaction", default=None)
-    currency: str | None = Field(
-        description="Currency code (ISO 4217) of the transaction", default=None
-    )
+    currency: str | None = Field(description="Currency code (ISO 4217) of the transaction", default=None)
     note: str | None = Field(description="Note or description of the transaction", default=None)
 
 
@@ -85,9 +74,7 @@ def _to_amount_fragment(amount: Decimal) -> str:
     return as_text or "0"
 
 
-def _get_parse_validation_failure_reason(
-    parsed: ParsedSmsTransaction, message_text: str
-) -> str | None:
+def _get_parse_validation_failure_reason(parsed: ParsedSmsTransaction, message_text: str) -> str | None:
     if parsed.amount is None:
         return "amount is missing"
     if parsed.amount == 0:
@@ -104,10 +91,7 @@ def _get_parse_validation_failure_reason(
     normalized_message_text = lower_message_text.replace(",", "")
     if amount_fragment.lower() in normalized_message_text:
         return None
-    return (
-        "absolute amount fragment not found in source text "
-        f"(fragment={amount_fragment})"
-    )
+    return f"absolute amount fragment not found in source text (fragment={amount_fragment})"
 
 
 async def parse_sms_transaction(message_text: str) -> ParsedSmsTransaction | None:

--- a/backend_new/app/services/telegram_callback_data.py
+++ b/backend_new/app/services/telegram_callback_data.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+from dataclasses import dataclass
+
+from app.core.config import get_settings
+
+CALLBACK_VERSION = "cs1"
+ACTION_SET = "s"
+ACTION_REMOVE = "r"
+
+
+@dataclass(frozen=True)
+class CategoryCallbackPayload:
+    user_id: int
+    transaction_id: int
+    action: str
+    category_id: int | None
+
+
+def _to_base36(value: int) -> str:
+    if value < 0:
+        raise ValueError("value must be non-negative")
+    if value == 0:
+        return "0"
+    alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+    result = ""
+    current = value
+    while current:
+        current, remainder = divmod(current, 36)
+        result = alphabet[remainder] + result
+    return result
+
+
+def _from_base36(value: str) -> int:
+    return int(value, 36)
+
+
+def _sign(raw_payload: str) -> str:
+    secret = get_settings().telegram_webhook_secret.encode("utf-8")
+    digest = hmac.new(secret, raw_payload.encode("utf-8"), hashlib.sha256).hexdigest()
+    return digest[:16]
+
+
+def encode_category_callback_data(
+    *,
+    user_id: int,
+    transaction_id: int,
+    action: str,
+    category_id: int | None,
+) -> str:
+    if action not in {ACTION_SET, ACTION_REMOVE}:
+        raise ValueError("unsupported callback action")
+    if action == ACTION_SET and category_id is None:
+        raise ValueError("category_id is required for set action")
+    if action == ACTION_REMOVE:
+        category_fragment = "0"
+    else:
+        if category_id is None:
+            raise ValueError("category_id is required for set action")
+        category_fragment = _to_base36(category_id)
+
+    parts = [
+        CALLBACK_VERSION,
+        _to_base36(user_id),
+        _to_base36(transaction_id),
+        action,
+        category_fragment,
+    ]
+    raw_payload = ":".join(parts)
+    signature = _sign(raw_payload)
+    return f"{raw_payload}:{signature}"
+
+
+def decode_category_callback_data(payload: str) -> CategoryCallbackPayload | None:
+    parts = payload.split(":")
+    if len(parts) != 6:
+        return None
+    version, user_fragment, tx_fragment, action, category_fragment, signature = parts
+    if version != CALLBACK_VERSION:
+        return None
+    if action not in {ACTION_SET, ACTION_REMOVE}:
+        return None
+
+    raw_payload = ":".join(parts[:-1])
+    expected_signature = _sign(raw_payload)
+    if not hmac.compare_digest(expected_signature, signature):
+        return None
+
+    try:
+        user_id = _from_base36(user_fragment)
+        transaction_id = _from_base36(tx_fragment)
+    except ValueError:
+        return None
+
+    category_id: int | None
+    if action == ACTION_REMOVE:
+        if category_fragment != "0":
+            return None
+        category_id = None
+    else:
+        try:
+            category_id = _from_base36(category_fragment)
+        except ValueError:
+            return None
+        if category_id <= 0:
+            return None
+
+    return CategoryCallbackPayload(
+        user_id=user_id,
+        transaction_id=transaction_id,
+        action=action,
+        category_id=category_id,
+    )

--- a/backend_new/app/services/telegram_ingestion.py
+++ b/backend_new/app/services/telegram_ingestion.py
@@ -4,78 +4,70 @@ import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from telegram import Bot, Update
+from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
 
-from app.db.queries import (
-    upsert_transaction_by_message_id,
-)
+from app.db.queries import upsert_transaction_by_message_id
 from app.schemas.responses import TransactionResponse
+from app.services.category_suggestion import (
+    CategoryActionOption,
+    CategorySuggestionResult,
+    build_default_category_actions,
+    suggest_and_apply_transaction_category,
+)
 from app.services.sms_parser import parse_sms_transaction
+from app.services.telegram_callback_data import (
+    ACTION_REMOVE,
+    ACTION_SET,
+    decode_category_callback_data,
+    encode_category_callback_data,
+)
+from app.services.transaction_category_actions import (
+    GENERIC_UPDATE_ERROR_TEXT,
+    apply_category_callback_action,
+)
 
 logger = logging.getLogger(__name__)
 
-ALLOWED_TELEGRAM_USER_ID = 459885395
 UNPARSED_REPLY_TEXT = "Cannot parse the transaction"
 
 
 @dataclass(frozen=True)
 class NormalizedTelegramMessage:
+    chat_id: int
+    from_id: int
     message_date: int
     message_id: int
-    from_id: int
     message_text: str
+    is_edited: bool
 
 
-def _normalize_update(update: Update) -> NormalizedTelegramMessage | None:
-    edited_message = update.edited_message
-    message = update.message
-    if edited_message is None and message is None:
+def _normalize_message_update(update: Update) -> NormalizedTelegramMessage | None:
+    if update.edited_message is not None:
+        selected_message = update.edited_message
+        is_edited = True
+    elif update.message is not None:
+        selected_message = update.message
+        is_edited = False
+    else:
         return None
 
-    selected_date = (
-        edited_message.date
-        if edited_message is not None and edited_message.edit_date is not None
-        else message.date
-        if message is not None
-        else None
-    )
-    if selected_date is None:
+    if selected_message.from_user is None:
         return None
-
-    selected_message_id = (
-        edited_message.message_id
-        if edited_message is not None and edited_message.message_id is not None
-        else message.message_id
-        if message is not None
-        else None
-    )
-    if selected_message_id is None:
+    if selected_message.message_id is None:
         return None
-
-    from_user = (
-        edited_message.from_user
-        if edited_message is not None and edited_message.from_user is not None
-        else message.from_user
-        if message is not None
-        else None
-    )
-    if from_user is None:
+    if selected_message.date is None:
         return None
-
-    selected_text = (
-        edited_message.text
-        if edited_message is not None and edited_message.text and edited_message.text.strip()
-        else message.text
-        if message is not None and message.text is not None
-        else ""
-    )
+    if selected_message.chat is None:
+        return None
 
     return NormalizedTelegramMessage(
-        message_date=int(selected_date.timestamp()),
-        message_id=selected_message_id,
-        from_id=from_user.id,
-        message_text=selected_text,
+        chat_id=selected_message.chat.id,
+        from_id=selected_message.from_user.id,
+        message_date=int(selected_message.date.timestamp()),
+        message_id=selected_message.message_id,
+        message_text=selected_message.text or "",
+        is_edited=is_edited,
     )
 
 
@@ -87,18 +79,61 @@ async def _send_unparsed(bot: Bot, *, chat_id: int, reply_to_message_id: int) ->
     )
 
 
+def _build_category_keyboard(
+    *,
+    user_id: int,
+    transaction_id: int,
+    top3_options: list[CategoryActionOption],
+) -> InlineKeyboardMarkup:
+    top3_buttons = [
+        InlineKeyboardButton(
+            text=option.category_name,
+            callback_data=encode_category_callback_data(
+                user_id=user_id,
+                transaction_id=transaction_id,
+                action=ACTION_SET,
+                category_id=option.category_id,
+            ),
+        )
+        for option in top3_options
+    ]
+    remove_button = InlineKeyboardButton(
+        text="Remove category",
+        callback_data=encode_category_callback_data(
+            user_id=user_id,
+            transaction_id=transaction_id,
+            action=ACTION_REMOVE,
+            category_id=None,
+        ),
+    )
+    keyboard_rows: list[list[InlineKeyboardButton]] = []
+    if top3_buttons:
+        keyboard_rows.append(top3_buttons)
+    keyboard_rows.append([remove_button])
+    return InlineKeyboardMarkup(keyboard_rows)
+
+
 async def _send_create_reply(
     bot: Bot,
     *,
     chat_id: int,
+    user_id: int,
     reply_to_message_id: int,
     transaction: TransactionResponse,
+    suggestion: CategorySuggestionResult,
 ) -> None:
     note = transaction.note or ""
     formatted_amount = f"{transaction.amount:.2f}"
+    category_name = suggestion.applied_category_name or "Not assigned"
+    keyboard = _build_category_keyboard(
+        user_id=user_id,
+        transaction_id=transaction.id,
+        top3_options=suggestion.top3_options,
+    )
     text = (
         "Transaction was saved.\n"
         f"Date: {transaction.transactionDate.isoformat()}\n"
+        f"Category: {category_name}\n"
         f"Amount: {formatted_amount}\n"
         f"Currency: {transaction.currency}\n"
         f"Note: {note}"
@@ -107,60 +142,129 @@ async def _send_create_reply(
         chat_id=chat_id,
         text=text,
         reply_to_message_id=reply_to_message_id,
+        reply_markup=keyboard,
     )
+
+
+async def _resolve_suggestion(
+    *,
+    normalized: NormalizedTelegramMessage,
+    transaction: TransactionResponse,
+) -> CategorySuggestionResult:
+    if normalized.is_edited and transaction.categoryId is not None:
+        return await build_default_category_actions(
+            preferred_category_id=transaction.categoryId,
+            amount=transaction.amount,
+        )
+    return await suggest_and_apply_transaction_category(
+        user_id=normalized.from_id,
+        transaction=transaction,
+    )
+
+
+async def _handle_message_update(
+    *,
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> None:
+    normalized = _normalize_message_update(update)
+    if normalized is None:
+        return
+
+    parsed = await parse_sms_transaction(normalized.message_text)
+    if parsed is None:
+        await _send_unparsed(
+            context.bot,
+            chat_id=normalized.chat_id,
+            reply_to_message_id=normalized.message_id,
+        )
+        return
+
+    amount = parsed.amount
+    currency = parsed.currency
+    if amount is None or currency is None:
+        await _send_unparsed(
+            context.bot,
+            chat_id=normalized.chat_id,
+            reply_to_message_id=normalized.message_id,
+        )
+        return
+
+    created = await upsert_transaction_by_message_id(
+        user_id=normalized.from_id,
+        message_id=str(normalized.message_id),
+        transaction_date=datetime.fromtimestamp(normalized.message_date, tz=UTC),
+        amount=amount,
+        currency=currency,
+        note=parsed.note,
+        sms_text=normalized.message_text,
+    )
+    suggestion = await _resolve_suggestion(normalized=normalized, transaction=created)
+
+    await _send_create_reply(
+        context.bot,
+        chat_id=normalized.chat_id,
+        user_id=normalized.from_id,
+        reply_to_message_id=normalized.message_id,
+        transaction=created,
+        suggestion=suggestion,
+    )
+
+
+async def _handle_callback_query(
+    *,
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> None:
+    callback_query = update.callback_query
+    if callback_query is None:
+        return
+    if callback_query.from_user is None:
+        return
+
+    message = callback_query.message
+    chat_id = message.chat.id if message is not None else callback_query.from_user.id
+    try:
+        callback_payload = decode_category_callback_data(callback_query.data or "")
+        if callback_payload is None:
+            await context.bot.send_message(chat_id=chat_id, text=GENERIC_UPDATE_ERROR_TEXT)
+            return
+
+        result = await apply_category_callback_action(
+            actor_user_id=callback_query.from_user.id,
+            payload=callback_payload,
+        )
+        await context.bot.send_message(chat_id=chat_id, text=result.message)
+    except Exception as exc:
+        logger.error("Failed to process Telegram callback query: %s", exc, exc_info=True)
+        await context.bot.send_message(chat_id=chat_id, text=GENERIC_UPDATE_ERROR_TEXT)
+    finally:
+        callback_query_id = callback_query.id
+        if callback_query_id is not None:
+            try:
+                await context.bot.answer_callback_query(callback_query_id=callback_query_id)
+            except Exception as exc:
+                logger.error("Failed to acknowledge Telegram callback query: %s", exc, exc_info=True)
 
 
 async def handle_telegram_update(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not isinstance(update, Update):
         return
 
-    normalized = _normalize_update(update)
-    if normalized is None:
-        return
-    if normalized.from_id != ALLOWED_TELEGRAM_USER_ID:
-        return
-
     try:
-        parsed = await parse_sms_transaction(normalized.message_text)
-        if parsed is None:
-            await _send_unparsed(
-                context.bot,
-                chat_id=normalized.from_id,
-                reply_to_message_id=normalized.message_id,
-            )
+        if update.callback_query is not None:
+            await _handle_callback_query(update=update, context=context)
             return
-
-        amount = parsed.amount
-        currency = parsed.currency
-        if amount is None or currency is None:
-            await _send_unparsed(
-                context.bot,
-                chat_id=normalized.from_id,
-                reply_to_message_id=normalized.message_id,
-            )
-            return
-
-        created = await upsert_transaction_by_message_id(
-            user_id=normalized.from_id,
-            message_id=str(normalized.message_id),
-            transaction_date=datetime.fromtimestamp(normalized.message_date, tz=UTC),
-            amount=amount,
-            currency=currency,
-            note=parsed.note,
-            sms_text=normalized.message_text,
-        )
-        await _send_create_reply(
-            context.bot,
-            chat_id=normalized.from_id,
-            reply_to_message_id=normalized.message_id,
-            transaction=created,
-        )
+        await _handle_message_update(update=update, context=context)
     except Exception as exc:
         logger.error("Failed to process Telegram update: %s", exc, exc_info=True)
+        normalized = _normalize_message_update(update)
+        if normalized is None:
+            return
         try:
             await _send_unparsed(
                 context.bot,
-                chat_id=normalized.from_id,
+                chat_id=normalized.chat_id,
                 reply_to_message_id=normalized.message_id,
             )
         except Exception as send_exc:

--- a/backend_new/app/services/telegram_runtime.py
+++ b/backend_new/app/services/telegram_runtime.py
@@ -11,7 +11,7 @@ from app.services.telegram_ingestion import handle_telegram_update
 
 logger = logging.getLogger(__name__)
 
-ALLOWED_UPDATES = ["message", "edited_message"]
+ALLOWED_UPDATES = ["message", "edited_message", "callback_query"]
 
 
 class TelegramBotRuntime:
@@ -36,9 +36,7 @@ class TelegramBotRuntime:
             logger.info("Telegram runtime is disabled: TELEGRAM_WEBHOOK_URL is not configured")
             return
         if not settings.telegram_webhook_secret.strip():
-            raise RuntimeError(
-                "TELEGRAM_WEBHOOK_SECRET must be configured when TELEGRAM_WEBHOOK_URL is set"
-            )
+            raise RuntimeError("TELEGRAM_WEBHOOK_SECRET must be configured when TELEGRAM_WEBHOOK_URL is set")
 
         application = Application.builder().token(settings.telegram_bot_token).updater(None).build()
         application.add_handler(TypeHandler(type=Update, callback=handle_telegram_update))

--- a/backend_new/app/services/transaction_category_actions.py
+++ b/backend_new/app/services/transaction_category_actions.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from app.db.queries import (
+    fetch_category_name_by_id,
+    fetch_transaction_by_id_for_user,
+    update_transaction_category_for_user,
+)
+from app.services.telegram_callback_data import (
+    ACTION_REMOVE,
+    ACTION_SET,
+    CategoryCallbackPayload,
+)
+
+logger = logging.getLogger(__name__)
+
+REMOVE_CONFIRMATION_TEXT = "Category removed. You can set it manually in app."
+GENERIC_UPDATE_ERROR_TEXT = "Could not update category. Please try again."
+
+
+@dataclass(frozen=True)
+class CategoryActionResult:
+    success: bool
+    message: str
+
+
+async def apply_category_callback_action(
+    *,
+    actor_user_id: int,
+    payload: CategoryCallbackPayload,
+) -> CategoryActionResult:
+    if actor_user_id != payload.user_id:
+        return CategoryActionResult(success=False, message=GENERIC_UPDATE_ERROR_TEXT)
+
+    transaction = await fetch_transaction_by_id_for_user(
+        user_id=actor_user_id,
+        transaction_id=payload.transaction_id,
+    )
+    if transaction is None:
+        return CategoryActionResult(success=False, message=GENERIC_UPDATE_ERROR_TEXT)
+
+    if payload.action == ACTION_SET:
+        if payload.category_id is None:
+            return CategoryActionResult(success=False, message=GENERIC_UPDATE_ERROR_TEXT)
+
+        category_name = await fetch_category_name_by_id(category_id=payload.category_id)
+        if category_name is None:
+            return CategoryActionResult(success=False, message=GENERIC_UPDATE_ERROR_TEXT)
+
+        if transaction.categoryId != payload.category_id:
+            updated = await update_transaction_category_for_user(
+                user_id=actor_user_id,
+                transaction_id=payload.transaction_id,
+                category_id=payload.category_id,
+            )
+            if updated is None:
+                return CategoryActionResult(success=False, message=GENERIC_UPDATE_ERROR_TEXT)
+            logger.info(
+                "event=category_overridden_by_user user_id=%s transaction_id=%s category_id=%s",
+                actor_user_id,
+                payload.transaction_id,
+                payload.category_id,
+            )
+
+        return CategoryActionResult(
+            success=True,
+            message=f"Category updated to: {category_name}",
+        )
+
+    if payload.action == ACTION_REMOVE:
+        if transaction.categoryId is None:
+            return CategoryActionResult(success=True, message=REMOVE_CONFIRMATION_TEXT)
+
+        updated = await update_transaction_category_for_user(
+            user_id=actor_user_id,
+            transaction_id=payload.transaction_id,
+            category_id=None,
+        )
+        if updated is None:
+            return CategoryActionResult(success=False, message=GENERIC_UPDATE_ERROR_TEXT)
+
+        logger.info(
+            "event=category_removed_by_user user_id=%s transaction_id=%s",
+            actor_user_id,
+            payload.transaction_id,
+        )
+        return CategoryActionResult(success=True, message=REMOVE_CONFIRMATION_TEXT)
+
+    return CategoryActionResult(success=False, message=GENERIC_UPDATE_ERROR_TEXT)

--- a/backend_new/piccolo_migrations/db_2026_02_21t22_05_00_000001.py
+++ b/backend_new/piccolo_migrations/db_2026_02_21t22_05_00_000001.py
@@ -50,15 +50,9 @@ async def _create_schema_parity() -> None:
         )
         """,
         "CREATE UNIQUE INDEX IF NOT EXISTS ix_category_name ON category (name)",
-        (
-            "CREATE INDEX IF NOT EXISTS ix_category_parent_category_id "
-            "ON category (parent_category_id)"
-        ),
+        ("CREATE INDEX IF NOT EXISTS ix_category_parent_category_id ON category (parent_category_id)"),
         'CREATE INDEX IF NOT EXISTS ix_transaction_category_id ON "transaction" (category_id)',
-        (
-            "CREATE INDEX IF NOT EXISTS ix_transaction_transaction_date "
-            'ON "transaction" (transaction_date)'
-        ),
+        ('CREATE INDEX IF NOT EXISTS ix_transaction_transaction_date ON "transaction" (transaction_date)'),
         'CREATE INDEX IF NOT EXISTS ix_transaction_user_id ON "transaction" (user_id)',
         """
         CREATE UNIQUE INDEX IF NOT EXISTS ix_transaction_user_id_message_id

--- a/backend_new/tests/fixtures/db_helpers.py
+++ b/backend_new/tests/fixtures/db_helpers.py
@@ -35,10 +35,7 @@ class DbHelper:
         try:
             # Cleanup only namespaced artifacts created by this suite.
             await conn.execute(
-                (
-                    'DELETE FROM "transaction" '
-                    "WHERE message_id LIKE $1 OR note LIKE $2 OR sms_text LIKE $3"
-                ),
+                ('DELETE FROM "transaction" WHERE message_id LIKE $1 OR note LIKE $2 OR sms_text LIKE $3'),
                 f"{self._namespace}%",
                 f"{self._namespace}%",
                 f"{self._namespace}%",
@@ -113,6 +110,31 @@ class DbHelper:
                 WHERE id = $1
                 """,
                 tx_id,
+            )
+        finally:
+            await conn.close()
+        return dict(row) if row else None
+
+    async def get_transaction_by_user_and_message_id(
+        self,
+        *,
+        user_id: int,
+        message_id: str,
+    ) -> dict[str, Any] | None:
+        conn = await asyncpg.connect(self._database_url)
+        try:
+            row = await conn.fetchrow(
+                """
+                SELECT
+                    id, user_id, transaction_date, amount, note, category_id, tags, currency,
+                    sms_text, message_id
+                FROM "transaction"
+                WHERE user_id = $1 AND message_id = $2
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                user_id,
+                message_id,
             )
         finally:
             await conn.close()

--- a/backend_new/tests/integration/conftest.py
+++ b/backend_new/tests/integration/conftest.py
@@ -152,9 +152,7 @@ def record_result(request: pytest.FixtureRequest):
 
 @pytest.fixture
 def perform_request(record_result):
-    def _perform(
-        client: httpx.Client, method: str, url: str, path: str, **kwargs: Any
-    ) -> tuple[httpx.Response, Any]:
+    def _perform(client: httpx.Client, method: str, url: str, path: str, **kwargs: Any) -> tuple[httpx.Response, Any]:
         response = client.request(method, f"{url}{path}", **kwargs)
         body = _json_or_text(response)
         record_result(method=method.upper(), path=path, status_code=response.status_code, body=body)
@@ -177,6 +175,4 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
 
     output_path = Path(output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(
-        json.dumps(serialized, indent=2, ensure_ascii=True) + "\n", encoding="utf-8"
-    )
+    output_path.write_text(json.dumps(serialized, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")

--- a/backend_new/tests/integration/test_api_parity.py
+++ b/backend_new/tests/integration/test_api_parity.py
@@ -490,10 +490,7 @@ def test_transactions_filter_by_min_max_amount(
             )
         )
 
-    path = (
-        f"/api/transactions/?tags={amount_tag}&minAmount={min_amount}"
-        f"&maxAmount={max_amount}&take=100"
-    )
+    path = f"/api/transactions/?tags={amount_tag}&minAmount={min_amount}&maxAmount={max_amount}&take=100"
     response, body = perform_request(http_client, "GET", base_url, path)
 
     assert response.status_code == 200
@@ -512,12 +509,8 @@ def test_transactions_filter_by_category_id(
     perform_request,
 ) -> None:
     filter_tag = _unique_value(db_helper.namespace, "category-filter")
-    keep_category_id = asyncio.run(
-        db_helper.insert_category(name=_unique_value(db_helper.namespace, "KeepCategory"))
-    )
-    other_category_id = asyncio.run(
-        db_helper.insert_category(name=_unique_value(db_helper.namespace, "OtherCategory"))
-    )
+    keep_category_id = asyncio.run(db_helper.insert_category(name=_unique_value(db_helper.namespace, "KeepCategory")))
+    other_category_id = asyncio.run(db_helper.insert_category(name=_unique_value(db_helper.namespace, "OtherCategory")))
     keep_note = _unique_value(db_helper.namespace, "category-keep")
     other_note = _unique_value(db_helper.namespace, "category-other")
 
@@ -637,9 +630,7 @@ def test_transactions_filter_by_text_note_tag_amount_category(
     )
 
     for term in [note_term, tag_term, amount_term, category_name.lower()]:
-        response, body = perform_request(
-            http_client, "GET", base_url, f"/api/transactions/?text={term}&take=100"
-        )
+        response, body = perform_request(http_client, "GET", base_url, f"/api/transactions/?text={term}&take=100")
         assert response.status_code == 200
         assert body["totalCount"] >= 1
 
@@ -654,9 +645,7 @@ def test_create_transaction_persists_expected_defaults_and_fields(
     note = _unique_value(db_helper.namespace, "create-note")
     payload = _transaction_payload(message_id=message_id, note=note)
 
-    response, body = perform_request(
-        http_client, "POST", base_url, "/api/transactions/", json=payload
-    )
+    response, body = perform_request(http_client, "POST", base_url, "/api/transactions/", json=payload)
 
     assert response.status_code == 201
     assert response.headers["location"] == f"/api/transactions/{body['id']}"
@@ -687,9 +676,7 @@ def test_create_transaction_with_category_returns_null_embedded_category(
     note = _unique_value(db_helper.namespace, "create-category-note")
     payload = _transaction_payload(message_id=message_id, note=note, category_id=category_id)
 
-    response, body = perform_request(
-        http_client, "POST", base_url, "/api/transactions/", json=payload
-    )
+    response, body = perform_request(http_client, "POST", base_url, "/api/transactions/", json=payload)
 
     assert response.status_code == 201
     assert body["categoryId"] == category_id
@@ -713,9 +700,7 @@ def test_create_transaction_omits_null_optional_fields_in_response(
         "messageId": None,
     }
 
-    response, body = perform_request(
-        http_client, "POST", base_url, "/api/transactions/", json=payload
-    )
+    response, body = perform_request(http_client, "POST", base_url, "/api/transactions/", json=payload)
 
     assert response.status_code == 201
     assert body["amount"] == payload["amount"]
@@ -743,9 +728,7 @@ def test_create_transaction_accepts_negative_and_positive_amounts(
     note = _unique_value(db_helper.namespace, f"create-sign-{amount_label}")
     payload = _transaction_payload(message_id=message_id, note=note, amount=amount)
 
-    response, body = perform_request(
-        http_client, "POST", base_url, "/api/transactions/", json=payload
-    )
+    response, body = perform_request(http_client, "POST", base_url, "/api/transactions/", json=payload)
 
     assert response.status_code == 201
     assert body["amount"] == amount
@@ -790,9 +773,7 @@ def test_update_transaction_owned_success(
         "currency": "AED",
     }
 
-    response, body = perform_request(
-        http_client, "PUT", base_url, f"/api/transactions/{tx_id}", json=payload
-    )
+    response, body = perform_request(http_client, "PUT", base_url, f"/api/transactions/{tx_id}", json=payload)
 
     assert response.status_code == 200
     assert body["id"] == tx_id
@@ -832,9 +813,7 @@ def test_update_transaction_not_owned_returns_not_found(
         "currency": "AED",
     }
 
-    response, _ = perform_request(
-        http_client, "PUT", base_url, f"/api/transactions/{tx_id}", json=payload
-    )
+    response, _ = perform_request(http_client, "PUT", base_url, f"/api/transactions/{tx_id}", json=payload)
     assert response.status_code == 404
 
 
@@ -853,9 +832,7 @@ def test_update_transaction_missing_returns_not_found(
         "currency": "AED",
     }
 
-    response, _ = perform_request(
-        http_client, "PUT", base_url, "/api/transactions/99999999", json=payload
-    )
+    response, _ = perform_request(http_client, "PUT", base_url, "/api/transactions/99999999", json=payload)
     assert response.status_code == 404
 
 
@@ -971,21 +948,13 @@ def test_unique_user_message_constraint_enforced(
     perform_request,
 ) -> None:
     message_id = _unique_value(db_helper.namespace, "msg-unique")
-    payload = _transaction_payload(
-        message_id=message_id, note=_unique_value(db_helper.namespace, "unique-a")
-    )
+    payload = _transaction_payload(message_id=message_id, note=_unique_value(db_helper.namespace, "unique-a"))
 
-    first_response, _ = perform_request(
-        http_client, "POST", base_url, "/api/transactions/", json=payload
-    )
+    first_response, _ = perform_request(http_client, "POST", base_url, "/api/transactions/", json=payload)
     assert first_response.status_code == 201
 
-    duplicate_payload = _transaction_payload(
-        message_id=message_id, note=_unique_value(db_helper.namespace, "unique-b")
-    )
-    second_response, body = perform_request(
-        http_client, "POST", base_url, "/api/transactions/", json=duplicate_payload
-    )
+    duplicate_payload = _transaction_payload(message_id=message_id, note=_unique_value(db_helper.namespace, "unique-b"))
+    second_response, body = perform_request(http_client, "POST", base_url, "/api/transactions/", json=duplicate_payload)
 
     assert second_response.status_code == 500
     assert isinstance(body, dict)
@@ -997,9 +966,7 @@ def test_category_fk_set_null_on_category_delete(
     db_helper: DbHelper,
     test_user_id: int,
 ) -> None:
-    category_id = asyncio.run(
-        db_helper.insert_category(name=_unique_value(db_helper.namespace, "fk-set-null"))
-    )
+    category_id = asyncio.run(db_helper.insert_category(name=_unique_value(db_helper.namespace, "fk-set-null")))
     tx_id = asyncio.run(
         db_helper.insert_transaction(
             SeedTransaction(
@@ -1079,9 +1046,7 @@ def test_transactions_text_search_matches_tag_substring_case_insensitive(
         )
     )
 
-    response, body = perform_request(
-        http_client, "GET", base_url, "/api/transactions/?text=betag&take=100"
-    )
+    response, body = perform_request(http_client, "GET", base_url, "/api/transactions/?text=betag&take=100")
 
     assert response.status_code == 200
     notes = {item.get("note") for item in body["data"]}
@@ -1130,9 +1095,7 @@ def test_transactions_text_search_matches_amount_substring_not_only_exact(
         )
     )
 
-    response, body = perform_request(
-        http_client, "GET", base_url, "/api/transactions/?text=45.6&take=100"
-    )
+    response, body = perform_request(http_client, "GET", base_url, "/api/transactions/?text=45.6&take=100")
 
     assert response.status_code == 200
     notes = {item.get("note") for item in body["data"]}

--- a/backend_new/tests/integration/test_sms_parser_llm_e2e.py
+++ b/backend_new/tests/integration/test_sms_parser_llm_e2e.py
@@ -27,8 +27,7 @@ SMS_PARSER_E2E_CASES: list[SmsParserE2ECase] = [
     SmsParserE2ECase(
         name="wio_usd_with_aed_converted_amount",
         input_text=(
-            "Payment of USD 10 (AED 37) was done at Github inc "
-            "using your Wio Personal card 9759 with Credit money"
+            "Payment of USD 10 (AED 37) was done at Github inc using your Wio Personal card 1234 with Credit money"
         ),
         expected_amount=Decimal("-37"),
         expected_currency="AED",
@@ -37,7 +36,7 @@ SMS_PARSER_E2E_CASES: list[SmsParserE2ECase] = [
     SmsParserE2ECase(
         name="loan_installment_with_grouped_amount",
         input_text=(
-            "AED 2,343.00 has been debited from your account 101XXX34XXX02 "
+            "AED 2,343.00 has been debited from your account 123XXX45XXX67 "
             "for loan installment. The available balance is AED 658.63"
         ),
         expected_amount=Decimal("-2343"),
@@ -57,8 +56,7 @@ SMS_PARSER_E2E_CASES: list[SmsParserE2ECase] = [
     SmsParserE2ECase(
         name="wio_purchase_with_grouped_amount",
         input_text=(
-            "Payment of AED 3,345.3 was done at Sukoon insurance "
-            "using your Wio Personal card 4027 with Credit money"
+            "Payment of AED 3,345.3 was done at Sukoon insurance using your Wio Personal card 1234 with Credit money"
         ),
         expected_amount=Decimal("-3345.3"),
         expected_currency="AED",
@@ -80,22 +78,20 @@ SMS_PARSER_E2E_CASES: list[SmsParserE2ECase] = [
     # ),
     SmsParserE2ECase(
         name="cbd_loan_installment_compact_aed",
-        input_text=(
-            "A loan installment of AED5211.56 for LMF*****3902 is debited from CBD account #xxx5597"
-        ),
+        input_text=("A loan installment of AED5211.56 for LMF*****3355 is debited from CBD account #xxx1234"),
         expected_amount=Decimal("-5211.56"),
         expected_currency="AED",
-        expected_note="loan installment for LMF*****3902",
+        expected_note="loan installment for LMF*****3355",
     ),
     SmsParserE2ECase(
         name="salary_credit",
         input_text=(
             "AED 12,000.00 has been credited to your account no. 101XXX34XXX02 DTB "
-            "SALARY EPBCOP056091J2J2 BY RAPYD MANAGEMENT LIMITEDSalary"
+            "SALARY SPBZXC122345Z7X8 BY ORCHID DEVELOPMENT LIMITEDSalary"
         ),
         expected_amount=Decimal("12000.00"),
         expected_currency="AED",
-        expected_note="RAPYD MANAGEMENT LIMITEDSalary",
+        expected_note="ORCHID DEVELOPMENT LIMITEDSalary",
     ),
 ]
 
@@ -170,11 +166,7 @@ def test_sms_parser_real_llm(case: SmsParserE2ECase) -> None:
 
     parsed = asyncio.run(parse_sms_transaction(case.input_text))
 
-    if (
-        case.expected_amount is None
-        and case.expected_currency is None
-        and case.expected_note is None
-    ):
+    if case.expected_amount is None and case.expected_currency is None and case.expected_note is None:
         assert parsed is None
         return
 

--- a/backend_new/tests/integration/test_telegram_category_suggestion_e2e.py
+++ b/backend_new/tests/integration/test_telegram_category_suggestion_e2e.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from telegram import Bot, InlineKeyboardMarkup, Update
+
+from app.core.config import get_settings
+from app.db.engine import get_engine
+from app.services.telegram_callback_data import decode_category_callback_data
+from app.services.telegram_ingestion import handle_telegram_update
+from tests.fixtures import DbHelper, SeedTransaction
+
+
+@dataclass
+class _FakeBot:
+    sent_messages: list[dict[str, object]] = field(default_factory=list)
+    answered_callback_query_ids: list[str] = field(default_factory=list)
+
+    async def send_message(
+        self,
+        *,
+        chat_id: int,
+        text: str,
+        reply_to_message_id: int | None = None,
+        reply_markup: InlineKeyboardMarkup | None = None,
+    ) -> None:
+        self.sent_messages.append(
+            {
+                "chat_id": chat_id,
+                "text": text,
+                "reply_to_message_id": reply_to_message_id,
+                "reply_markup": reply_markup,
+            }
+        )
+
+    async def answer_callback_query(
+        self,
+        *,
+        callback_query_id: str,
+    ) -> None:
+        self.answered_callback_query_ids.append(callback_query_id)
+
+
+@dataclass
+class _FakeContext:
+    bot: _FakeBot
+
+
+def _read_env_file_values() -> dict[str, str]:
+    env_path = Path(__file__).resolve().parents[2] / ".env"
+    if not env_path.exists():
+        return {}
+
+    values: dict[str, str] = {}
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+def _env_value(key: str) -> str | None:
+    return os.getenv(key) or _read_env_file_values().get(key)
+
+
+def _seed_required_runtime_env() -> None:
+    env_values = _read_env_file_values()
+    for key, value in env_values.items():
+        os.environ[key] = value
+    get_settings.cache_clear()
+
+
+def _require_llm_e2e_enabled() -> None:
+    _seed_required_runtime_env()
+    run_llm_e2e = _env_value("RUN_LLM_E2E")
+    if run_llm_e2e not in {"1", "true", "TRUE", "yes", "YES"}:
+        pytest.skip("Set RUN_LLM_E2E=1 (env or backend_new/.env) to run real LLM parser tests.")
+    if not _env_value("OPENAI_API_KEY"):
+        pytest.skip("Set OPENAI_API_KEY (env or backend_new/.env) to run real LLM parser tests.")
+
+
+def _build_message_update(*, user_id: int, message_id: int, text: str) -> Update:
+    payload = {
+        "update_id": 1,
+        "message": {
+            "message_id": message_id,
+            "date": int(datetime.now(UTC).timestamp()),
+            "from": {"id": user_id, "is_bot": False, "first_name": "Aleksei"},
+            "chat": {"id": user_id, "type": "private"},
+            "text": text,
+        },
+    }
+    update = Update.de_json(payload, Bot("123456:ABCDEF"))
+    assert update is not None
+    return update
+
+
+def _build_callback_update(*, user_id: int, callback_data: str) -> Update:
+    payload = {
+        "update_id": 2,
+        "callback_query": {
+            "id": "cbq-1",
+            "from": {"id": user_id, "is_bot": False, "first_name": "Aleksei"},
+            "chat_instance": "ci-1",
+            "data": callback_data,
+            "message": {
+                "message_id": 30,
+                "date": int(datetime.now(UTC).timestamp()),
+                "chat": {"id": user_id, "type": "private"},
+                "text": "Saved",
+            },
+        },
+    }
+    update = Update.de_json(payload, Bot("123456:ABCDEF"))
+    assert update is not None
+    return update
+
+
+async def _run_telegram_category_suggestion_e2e(
+    *,
+    db_helper: DbHelper,
+    test_user_id: int,
+) -> None:
+    engine = get_engine()
+    await engine.start_connection_pool()
+    try:
+        now = datetime.now(UTC)
+        groceries_id = await db_helper.insert_category(
+            name=f"{db_helper.namespace}Groceries",
+            category_type="Expense",
+            order_index=1,
+        )
+        eating_out_id = await db_helper.insert_category(
+            name=f"{db_helper.namespace}EatingOut",
+            category_type="Expense",
+            order_index=2,
+        )
+        home_id = await db_helper.insert_category(
+            name=f"{db_helper.namespace}Home",
+            category_type="Expense",
+            order_index=3,
+        )
+        await db_helper.insert_transaction(
+            SeedTransaction(
+                user_id=test_user_id,
+                transaction_date=now - timedelta(days=2),
+                amount=Decimal("-50.00"),
+                note="Github inc",
+                category_id=groceries_id,
+                tags=[],
+                currency="AED",
+                sms_text=f"{db_helper.namespace}hist-1",
+                message_id=f"{db_helper.namespace}msg-hist-1",
+            )
+        )
+        await db_helper.insert_transaction(
+            SeedTransaction(
+                user_id=test_user_id,
+                transaction_date=now - timedelta(days=1),
+                amount=Decimal("-75.00"),
+                note="Github inc subscription",
+                category_id=eating_out_id,
+                tags=[],
+                currency="AED",
+                sms_text=f"{db_helper.namespace}hist-2",
+                message_id=f"{db_helper.namespace}msg-hist-2",
+            )
+        )
+        await db_helper.insert_transaction(
+            SeedTransaction(
+                user_id=test_user_id,
+                transaction_date=now - timedelta(days=3),
+                amount=Decimal("-88.00"),
+                note="Github inc annual plan",
+                category_id=home_id,
+                tags=[],
+                currency="AED",
+                sms_text=f"{db_helper.namespace}hist-3",
+                message_id=f"{db_helper.namespace}msg-hist-3",
+            )
+        )
+
+        message_id_seed = 700000 + sum(ord(ch) for ch in db_helper.namespace) % 200000
+        sms_text = (
+            "Payment of USD 10 (AED 37) was done at Github inc using your Wio Personal card 9759 with Credit money"
+        )
+        context: _FakeContext | None = None
+        first_message: dict[str, object] | None = None
+        message_id = message_id_seed
+        for attempt in range(3):
+            current_message_id = message_id_seed + attempt
+            current_context = _FakeContext(bot=_FakeBot())
+            message_update = _build_message_update(
+                user_id=test_user_id,
+                message_id=current_message_id,
+                text=sms_text,
+            )
+            await handle_telegram_update(message_update, current_context)
+            if len(current_context.bot.sent_messages) == 1 and "Transaction was saved." in str(
+                current_context.bot.sent_messages[0]["text"]
+            ):
+                context = current_context
+                first_message = current_context.bot.sent_messages[0]
+                message_id = current_message_id
+                break
+        if context is None or first_message is None:
+            pytest.skip("Real LLM parser couldn't parse the SMS after 3 attempts")
+
+        first_text = str(first_message["text"])
+        assert "Category:" in first_text
+
+        reply_markup = first_message["reply_markup"]
+        assert isinstance(reply_markup, InlineKeyboardMarkup)
+        buttons = [button for row in reply_markup.inline_keyboard for button in row]
+        assert len(buttons) == 4
+        assert str(buttons[-1].text) == "Remove category"
+
+        top_payloads = [decode_category_callback_data(str(button.callback_data)) for button in buttons[:3]]
+        assert all(payload is not None for payload in top_payloads)
+        top_payload_values = [payload for payload in top_payloads if payload is not None]
+        assert len(top_payload_values) == 3
+        top_category_ids = [payload.category_id for payload in top_payload_values]
+        assert all(category_id is not None for category_id in top_category_ids)
+        assert len(set(top_category_ids)) == 3
+
+        saved = await db_helper.get_transaction_by_user_and_message_id(
+            user_id=test_user_id,
+            message_id=str(message_id),
+        )
+        assert saved is not None
+        assert saved["category_id"] is not None
+        assert int(saved["category_id"]) == int(top_payload_values[0].category_id or 0)
+
+        second_callback_update = _build_callback_update(
+            user_id=test_user_id,
+            callback_data=str(buttons[1].callback_data),
+        )
+        await handle_telegram_update(second_callback_update, context)
+        saved_after_override = await db_helper.get_transaction_by_user_and_message_id(
+            user_id=test_user_id,
+            message_id=str(message_id),
+        )
+        assert saved_after_override is not None
+        assert int(saved_after_override["category_id"]) == int(top_payload_values[1].category_id or 0)
+        assert "Category updated to:" in str(context.bot.sent_messages[-1]["text"])
+
+        remove_callback_update = _build_callback_update(
+            user_id=test_user_id,
+            callback_data=str(buttons[3].callback_data),
+        )
+        await handle_telegram_update(remove_callback_update, context)
+        saved_after_remove = await db_helper.get_transaction_by_user_and_message_id(
+            user_id=test_user_id,
+            message_id=str(message_id),
+        )
+        assert saved_after_remove is not None
+        assert saved_after_remove["category_id"] is None
+        assert str(context.bot.sent_messages[-1]["text"]) == "Category removed. You can set it manually in app."
+    finally:
+        await engine.close_connection_pool()
+
+
+def test_telegram_category_suggestion_e2e_real_llm(
+    db_helper: DbHelper,
+    test_user_id: int,
+) -> None:
+    _require_llm_e2e_enabled()
+    asyncio.run(
+        _run_telegram_category_suggestion_e2e(
+            db_helper=db_helper,
+            test_user_id=test_user_id,
+        )
+    )

--- a/backend_new/tests/test_category_suggestion.py
+++ b/backend_new/tests/test_category_suggestion.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from app.db.queries import SimilarCategoryExample
+from app.schemas.responses import CategoryResponse, TransactionResponse
+from app.services.category_suggestion import (
+    CategorySuggestionLlmOutput,
+    build_default_category_actions,
+    suggest_and_apply_transaction_category,
+)
+
+
+def _category(
+    *,
+    category_id: int,
+    name: str,
+    order_index: int,
+    category_type: str = "Expense",
+) -> CategoryResponse:
+    return CategoryResponse(
+        id=category_id,
+        name=name,
+        type=category_type,
+        color=None,
+        icon=None,
+        parentCategoryId=None,
+        orderIndex=order_index,
+        createdAt=datetime(2025, 9, 19, tzinfo=UTC),
+    )
+
+
+def _transaction(
+    *,
+    category_id: int | None = None,
+    amount: float = 107.68,
+    sms_text: str = "Payment of AED 107.68 was done at Amazon",
+) -> TransactionResponse:
+    return TransactionResponse(
+        id=77,
+        userId=123,
+        transactionDate=datetime(2025, 9, 19, tzinfo=UTC),
+        amount=amount,
+        note="Amazon",
+        categoryId=category_id,
+        tags=[],
+        currency="AED",
+        smsText=sms_text,
+        messageId="15",
+        createdAt=datetime(2025, 9, 19, tzinfo=UTC),
+        category=None,
+    )
+
+
+def test_build_default_category_actions_prefers_current_category(monkeypatch) -> None:
+    categories = [
+        _category(category_id=1, name="Groceries", order_index=1),
+        _category(category_id=2, name="Eating Out", order_index=2),
+        _category(category_id=3, name="Home", order_index=3),
+        _category(category_id=4, name="Travel", order_index=4),
+    ]
+
+    async def _fetch_categories():
+        return categories
+
+    monkeypatch.setattr("app.services.category_suggestion.fetch_categories", _fetch_categories)
+
+    result = asyncio.run(build_default_category_actions(preferred_category_id=3))
+
+    assert result.applied_category_id == 3
+    assert result.applied_category_name == "Home"
+    assert [option.category_id for option in result.top3_options] == [3, 1, 2]
+
+
+def test_suggestion_filters_invalid_llm_ids_and_uses_fallback(monkeypatch) -> None:
+    categories = [
+        _category(category_id=1, name="Groceries", order_index=1),
+        _category(category_id=2, name="Eating Out", order_index=2),
+        _category(category_id=3, name="Home", order_index=3),
+        _category(category_id=4, name="Travel", order_index=4),
+    ]
+
+    async def _fetch_categories():
+        return categories
+
+    async def _fetch_examples(**_kwargs):
+        return [
+            SimilarCategoryExample(
+                note="Amazon",
+                amount=Decimal("-12.30"),
+                category_id=1,
+                category_name="Groceries",
+            )
+        ]
+
+    async def _call_llm(**_kwargs):
+        return CategorySuggestionLlmOutput(
+            top_category_id=999,
+            alternatives=[2, 2, 333],
+            confidence=0.6,
+            reason="test",
+        )
+
+    update_calls = 0
+
+    async def _update(**_kwargs):
+        nonlocal update_calls
+        update_calls += 1
+        return None
+
+    monkeypatch.setattr("app.services.category_suggestion.fetch_categories", _fetch_categories)
+    monkeypatch.setattr("app.services.category_suggestion.fetch_similar_category_examples", _fetch_examples)
+    monkeypatch.setattr("app.services.category_suggestion._call_category_suggestion_llm", _call_llm)
+    monkeypatch.setattr("app.services.category_suggestion.update_transaction_category_for_user", _update)
+
+    result = asyncio.run(
+        suggest_and_apply_transaction_category(
+            user_id=123,
+            transaction=_transaction(),
+        )
+    )
+
+    assert result.applied_category_id is None
+    assert [option.category_id for option in result.top3_options] == [2, 1, 3]
+    assert update_calls == 0
+
+
+def test_suggestion_applies_valid_top_category(monkeypatch) -> None:
+    categories = [
+        _category(category_id=1, name="Groceries", order_index=1),
+        _category(category_id=2, name="Eating Out", order_index=2),
+        _category(category_id=3, name="Home", order_index=3),
+        _category(category_id=4, name="Travel", order_index=4),
+    ]
+
+    async def _fetch_categories():
+        return categories
+
+    async def _fetch_examples(**_kwargs):
+        return []
+
+    async def _call_llm(**_kwargs):
+        return CategorySuggestionLlmOutput(
+            top_category_id=3,
+            alternatives=[3, 1, 2],
+            confidence=0.9,
+            reason="test",
+        )
+
+    async def _update(**_kwargs):
+        return _transaction(category_id=3)
+
+    monkeypatch.setattr("app.services.category_suggestion.fetch_categories", _fetch_categories)
+    monkeypatch.setattr("app.services.category_suggestion.fetch_similar_category_examples", _fetch_examples)
+    monkeypatch.setattr("app.services.category_suggestion._call_category_suggestion_llm", _call_llm)
+    monkeypatch.setattr("app.services.category_suggestion.update_transaction_category_for_user", _update)
+
+    result = asyncio.run(
+        suggest_and_apply_transaction_category(
+            user_id=123,
+            transaction=_transaction(),
+        )
+    )
+
+    assert result.applied_category_id == 3
+    assert result.applied_category_name == "Home"
+    assert [option.category_id for option in result.top3_options] == [3, 1, 2]
+
+
+def test_build_default_category_actions_prioritizes_income_for_positive_amount(monkeypatch) -> None:
+    categories = [
+        _category(category_id=1, name="Groceries", order_index=1, category_type="Expense"),
+        _category(category_id=2, name="Salary", order_index=2, category_type="Income"),
+        _category(category_id=3, name="Home", order_index=3, category_type="Expense"),
+        _category(category_id=4, name="Bonus", order_index=4, category_type="Income"),
+    ]
+
+    async def _fetch_categories():
+        return categories
+
+    monkeypatch.setattr("app.services.category_suggestion.fetch_categories", _fetch_categories)
+
+    result = asyncio.run(build_default_category_actions(amount=120.0))
+
+    assert [option.category_id for option in result.top3_options] == [2, 4, 1]
+
+
+def test_suggestion_sends_sms_text_to_llm(monkeypatch) -> None:
+    categories = [
+        _category(category_id=1, name="Groceries", order_index=1),
+        _category(category_id=2, name="Eating Out", order_index=2),
+        _category(category_id=3, name="Home", order_index=3),
+    ]
+
+    async def _fetch_categories():
+        return categories
+
+    async def _fetch_examples(**_kwargs):
+        return []
+
+    captured_sms_text: dict[str, str] = {}
+
+    async def _call_llm(**kwargs):
+        captured_sms_text["value"] = str(kwargs["sms_text"])
+        return CategorySuggestionLlmOutput(
+            top_category_id=None,
+            alternatives=[],
+            confidence=0.0,
+            reason="test",
+        )
+
+    monkeypatch.setattr("app.services.category_suggestion.fetch_categories", _fetch_categories)
+    monkeypatch.setattr("app.services.category_suggestion.fetch_similar_category_examples", _fetch_examples)
+    monkeypatch.setattr("app.services.category_suggestion._call_category_suggestion_llm", _call_llm)
+
+    sms_text = "Payment of AED 50 was done at Grocery"
+    asyncio.run(
+        suggest_and_apply_transaction_category(
+            user_id=123,
+            transaction=_transaction(sms_text=sms_text),
+        )
+    )
+
+    assert captured_sms_text["value"] == sms_text

--- a/backend_new/tests/test_logging_redaction.py
+++ b/backend_new/tests/test_logging_redaction.py
@@ -3,8 +3,8 @@ from app.core.logging import _redact_secrets
 
 def test_redact_telegram_bot_url_token() -> None:
     message = (
-        'HTTP Request: POST '
-        'https://api.telegram.org/bot1234567890:TEST_TOKEN_FOR_LOG_REDACTION_123456/sendMessage '
+        "HTTP Request: POST "
+        "https://api.telegram.org/bot1234567890:TEST_TOKEN_FOR_LOG_REDACTION_123456/sendMessage "
         '"HTTP/1.1 200 OK"'
     )
     redacted = _redact_secrets(message)

--- a/backend_new/tests/test_telegram_callback_data.py
+++ b/backend_new/tests/test_telegram_callback_data.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from app.core.config import get_settings
+from app.services.telegram_callback_data import (
+    ACTION_REMOVE,
+    ACTION_SET,
+    decode_category_callback_data,
+    encode_category_callback_data,
+)
+
+
+def test_callback_data_roundtrip_for_set(monkeypatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://postgres:password@127.0.0.1:5432/moneytrack")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret-value")
+    get_settings.cache_clear()
+
+    encoded = encode_category_callback_data(
+        user_id=123456,
+        transaction_id=987,
+        action=ACTION_SET,
+        category_id=44,
+    )
+    decoded = decode_category_callback_data(encoded)
+
+    assert decoded is not None
+    assert decoded.user_id == 123456
+    assert decoded.transaction_id == 987
+    assert decoded.action == ACTION_SET
+    assert decoded.category_id == 44
+
+
+def test_callback_data_roundtrip_for_remove(monkeypatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://postgres:password@127.0.0.1:5432/moneytrack")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret-value")
+    get_settings.cache_clear()
+
+    encoded = encode_category_callback_data(
+        user_id=123456,
+        transaction_id=987,
+        action=ACTION_REMOVE,
+        category_id=None,
+    )
+    decoded = decode_category_callback_data(encoded)
+
+    assert decoded is not None
+    assert decoded.user_id == 123456
+    assert decoded.transaction_id == 987
+    assert decoded.action == ACTION_REMOVE
+    assert decoded.category_id is None
+
+
+def test_callback_data_rejects_signature_tampering(monkeypatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://postgres:password@127.0.0.1:5432/moneytrack")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret-value")
+    get_settings.cache_clear()
+
+    encoded = encode_category_callback_data(
+        user_id=123456,
+        transaction_id=987,
+        action=ACTION_SET,
+        category_id=44,
+    )
+    tampered = encoded[:-1] + ("0" if encoded[-1] != "0" else "1")
+    decoded = decode_category_callback_data(tampered)
+
+    assert decoded is None

--- a/backend_new/tests/test_telegram_ingestion.py
+++ b/backend_new/tests/test_telegram_ingestion.py
@@ -5,31 +5,44 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from decimal import Decimal
 
-from telegram import Bot, Update
+from telegram import Bot, InlineKeyboardMarkup, Update
 
 from app.schemas.responses import TransactionResponse
+from app.services.category_suggestion import CategoryActionOption, CategorySuggestionResult
 from app.services.sms_parser import ParsedSmsTransaction
+from app.services.telegram_callback_data import CategoryCallbackPayload
 from app.services.telegram_ingestion import handle_telegram_update
+from app.services.transaction_category_actions import CategoryActionResult
 
 
 @dataclass
 class _FakeBot:
     sent_messages: list[dict[str, object]] = field(default_factory=list)
+    answered_callback_query_ids: list[str] = field(default_factory=list)
 
     async def send_message(
         self,
         *,
         chat_id: int,
         text: str,
-        reply_to_message_id: int,
+        reply_to_message_id: int | None = None,
+        reply_markup: InlineKeyboardMarkup | None = None,
     ) -> None:
         self.sent_messages.append(
             {
                 "chat_id": chat_id,
                 "text": text,
                 "reply_to_message_id": reply_to_message_id,
+                "reply_markup": reply_markup,
             }
         )
+
+    async def answer_callback_query(
+        self,
+        *,
+        callback_query_id: str,
+    ) -> None:
+        self.answered_callback_query_ids.append(callback_query_id)
 
 
 @dataclass
@@ -37,7 +50,11 @@ class _FakeContext:
     bot: _FakeBot
 
 
-def _build_update(*, from_id: int, reply_to_message_id: int | None = None, edited: bool = False) -> Update:
+def _build_message_update(
+    *,
+    from_id: int,
+    edited: bool = False,
+) -> Update:
     message_payload: dict[str, object] = {
         "message_id": 15,
         "date": 1758301908,
@@ -45,15 +62,6 @@ def _build_update(*, from_id: int, reply_to_message_id: int | None = None, edite
         "chat": {"id": from_id, "type": "private"},
         "text": "Payment of AED 107.68 was done at Amazon",
     }
-    if reply_to_message_id is not None:
-        message_payload["reply_to_message"] = {
-            "message_id": reply_to_message_id,
-            "date": 1758301800,
-            "from": {"id": from_id, "is_bot": False, "first_name": "Aleksei"},
-            "chat": {"id": from_id, "type": "private"},
-            "text": "Older message",
-        }
-
     payload: dict[str, object] = {"update_id": 1}
     if edited:
         edited_payload = dict(message_payload)
@@ -67,14 +75,39 @@ def _build_update(*, from_id: int, reply_to_message_id: int | None = None, edite
     return update
 
 
-def _sample_transaction(note: str) -> TransactionResponse:
+def _build_callback_update(*, from_id: int, callback_data: str) -> Update:
+    payload = {
+        "update_id": 2,
+        "callback_query": {
+            "id": "cbq-1",
+            "from": {"id": from_id, "is_bot": False, "first_name": "Aleksei"},
+            "chat_instance": "ci-1",
+            "data": callback_data,
+            "message": {
+                "message_id": 30,
+                "date": 1758301908,
+                "chat": {"id": from_id, "type": "private"},
+                "text": "Saved",
+            },
+        },
+    }
+    update = Update.de_json(payload, Bot("123456:ABCDEF"))
+    assert update is not None
+    return update
+
+
+def _sample_transaction(
+    *,
+    user_id: int,
+    category_id: int | None = None,
+) -> TransactionResponse:
     return TransactionResponse(
         id=1,
-        userId=459885395,
+        userId=user_id,
         transactionDate=datetime(2025, 9, 19, 13, 38, 28, tzinfo=UTC),
         amount=107.68,
-        note=note,
-        categoryId=None,
+        note="Amazon",
+        categoryId=category_id,
         tags=[],
         currency="AED",
         smsText="Payment of AED 107.68 was done at Amazon",
@@ -84,22 +117,23 @@ def _sample_transaction(note: str) -> TransactionResponse:
     )
 
 
-def test_telegram_ingestion_ignores_disallowed_user(monkeypatch) -> None:
-    parser_called = False
+def test_telegram_ingestion_processes_any_user(monkeypatch) -> None:
+    parser_calls = 0
 
     async def _parse(_: str):
-        nonlocal parser_called
-        parser_called = True
+        nonlocal parser_calls
+        parser_calls += 1
         return None
 
     monkeypatch.setattr("app.services.telegram_ingestion.parse_sms_transaction", _parse)
 
     context = _FakeContext(bot=_FakeBot())
-    update = _build_update(from_id=123)
+    update = _build_message_update(from_id=123)
     asyncio.run(handle_telegram_update(update, context))
 
-    assert parser_called is False
-    assert context.bot.sent_messages == []
+    assert parser_calls == 1
+    assert len(context.bot.sent_messages) == 1
+    assert context.bot.sent_messages[0]["text"] == "Cannot parse the transaction"
 
 
 def test_telegram_ingestion_sends_fallback_for_invalid_parse(monkeypatch) -> None:
@@ -109,53 +143,138 @@ def test_telegram_ingestion_sends_fallback_for_invalid_parse(monkeypatch) -> Non
     monkeypatch.setattr("app.services.telegram_ingestion.parse_sms_transaction", _parse)
 
     context = _FakeContext(bot=_FakeBot())
-    update = _build_update(from_id=459885395)
+    update = _build_message_update(from_id=459885395)
     asyncio.run(handle_telegram_update(update, context))
 
     assert len(context.bot.sent_messages) == 1
     assert context.bot.sent_messages[0]["text"] == "Cannot parse the transaction"
 
 
-def test_telegram_ingestion_creates_transaction(monkeypatch) -> None:
+def test_telegram_ingestion_creates_transaction_with_category_buttons(monkeypatch) -> None:
     async def _parse(_: str):
         return ParsedSmsTransaction(amount=Decimal("107.68"), currency="AED", note="Amazon")
-
-    async def _upsert(**_kwargs):
-        return _sample_transaction("Amazon")
-
-    monkeypatch.setattr("app.services.telegram_ingestion.parse_sms_transaction", _parse)
-    monkeypatch.setattr("app.services.telegram_ingestion.upsert_transaction_by_message_id", _upsert)
-
-    context = _FakeContext(bot=_FakeBot())
-    update = _build_update(from_id=459885395)
-    asyncio.run(handle_telegram_update(update, context))
-
-    assert len(context.bot.sent_messages) == 1
-    sent_text = str(context.bot.sent_messages[0]["text"])
-    assert "Transaction was saved." in sent_text
-    assert "Amount: 107.68" in sent_text
-
-
-def test_telegram_ingestion_edited_message_uses_same_upsert_path(monkeypatch) -> None:
-    async def _parse(_: str):
-        return ParsedSmsTransaction(amount=Decimal("107.68"), currency="AED", note="Amazon")
-
-    upsert_calls: list[dict[str, object]] = []
 
     async def _upsert(**kwargs):
-        upsert_calls.append(kwargs)
-        return _sample_transaction("Amazon")
+        return _sample_transaction(user_id=int(kwargs["user_id"]))
+
+    async def _suggest(**_kwargs):
+        return CategorySuggestionResult(
+            applied_category_id=10,
+            applied_category_name="Groceries",
+            top3_options=[
+                CategoryActionOption(category_id=10, category_name="Groceries"),
+                CategoryActionOption(category_id=11, category_name="Eating Out"),
+                CategoryActionOption(category_id=12, category_name="Home"),
+            ],
+        )
 
     monkeypatch.setattr("app.services.telegram_ingestion.parse_sms_transaction", _parse)
     monkeypatch.setattr("app.services.telegram_ingestion.upsert_transaction_by_message_id", _upsert)
+    monkeypatch.setattr("app.services.telegram_ingestion.suggest_and_apply_transaction_category", _suggest)
 
     context = _FakeContext(bot=_FakeBot())
-    update = _build_update(from_id=459885395, edited=True)
+    update = _build_message_update(from_id=459885395)
     asyncio.run(handle_telegram_update(update, context))
 
     assert len(context.bot.sent_messages) == 1
-    sent_text = str(context.bot.sent_messages[0]["text"])
+    sent = context.bot.sent_messages[0]
+    sent_text = str(sent["text"])
     assert "Transaction was saved." in sent_text
     assert "Amount: 107.68" in sent_text
-    assert len(upsert_calls) == 1
-    assert upsert_calls[0]["message_id"] == "15"
+    assert "Category: Groceries" in sent_text
+
+    reply_markup = sent["reply_markup"]
+    assert isinstance(reply_markup, InlineKeyboardMarkup)
+    buttons = [button for row in reply_markup.inline_keyboard for button in row]
+    assert len(buttons) == 4
+    assert str(buttons[-1].text) == "Remove category"
+
+
+def test_telegram_ingestion_edited_message_skips_llm_when_category_exists(monkeypatch) -> None:
+    async def _parse(_: str):
+        return ParsedSmsTransaction(amount=Decimal("107.68"), currency="AED", note="Amazon")
+
+    async def _upsert(**kwargs):
+        return _sample_transaction(user_id=int(kwargs["user_id"]), category_id=33)
+
+    suggest_calls = 0
+    default_calls = 0
+
+    async def _suggest(**_kwargs):
+        nonlocal suggest_calls
+        suggest_calls += 1
+        return CategorySuggestionResult(
+            applied_category_id=None,
+            applied_category_name=None,
+            top3_options=[],
+        )
+
+    async def _default(**_kwargs):
+        nonlocal default_calls
+        default_calls += 1
+        return CategorySuggestionResult(
+            applied_category_id=33,
+            applied_category_name="Internet-Services",
+            top3_options=[
+                CategoryActionOption(category_id=33, category_name="Internet-Services"),
+                CategoryActionOption(category_id=11, category_name="Eating Out"),
+                CategoryActionOption(category_id=12, category_name="Home"),
+            ],
+        )
+
+    monkeypatch.setattr("app.services.telegram_ingestion.parse_sms_transaction", _parse)
+    monkeypatch.setattr("app.services.telegram_ingestion.upsert_transaction_by_message_id", _upsert)
+    monkeypatch.setattr("app.services.telegram_ingestion.suggest_and_apply_transaction_category", _suggest)
+    monkeypatch.setattr("app.services.telegram_ingestion.build_default_category_actions", _default)
+
+    context = _FakeContext(bot=_FakeBot())
+    update = _build_message_update(from_id=459885395, edited=True)
+    asyncio.run(handle_telegram_update(update, context))
+
+    assert suggest_calls == 0
+    assert default_calls == 1
+    assert len(context.bot.sent_messages) == 1
+    sent_text = str(context.bot.sent_messages[0]["text"])
+    assert "Category: Internet-Services" in sent_text
+
+
+def test_telegram_ingestion_callback_query_updates_category(monkeypatch) -> None:
+    payload = CategoryCallbackPayload(
+        user_id=459885395,
+        transaction_id=15,
+        action="s",
+        category_id=11,
+    )
+
+    monkeypatch.setattr(
+        "app.services.telegram_ingestion.decode_category_callback_data",
+        lambda _value: payload,
+    )
+
+    async def _apply(**_kwargs):
+        return CategoryActionResult(success=True, message="Category updated to: Groceries")
+
+    monkeypatch.setattr("app.services.telegram_ingestion.apply_category_callback_action", _apply)
+
+    context = _FakeContext(bot=_FakeBot())
+    update = _build_callback_update(from_id=459885395, callback_data="cs1:data")
+    asyncio.run(handle_telegram_update(update, context))
+
+    assert len(context.bot.sent_messages) == 1
+    assert context.bot.sent_messages[0]["text"] == "Category updated to: Groceries"
+    assert context.bot.answered_callback_query_ids == ["cbq-1"]
+
+
+def test_telegram_ingestion_callback_query_invalid_payload(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.services.telegram_ingestion.decode_category_callback_data",
+        lambda _value: None,
+    )
+
+    context = _FakeContext(bot=_FakeBot())
+    update = _build_callback_update(from_id=459885395, callback_data="bad")
+    asyncio.run(handle_telegram_update(update, context))
+
+    assert len(context.bot.sent_messages) == 1
+    assert context.bot.sent_messages[0]["text"] == "Could not update category. Please try again."
+    assert context.bot.answered_callback_query_ids == ["cbq-1"]

--- a/backend_new/tests/test_telegram_runtime.py
+++ b/backend_new/tests/test_telegram_runtime.py
@@ -89,7 +89,7 @@ def test_telegram_runtime_registers_webhook(monkeypatch) -> None:
     assert fake_application.bot.webhook_calls == [
         {
             "url": "https://money-track.org/api/telegram/webhook",
-            "allowed_updates": ["message", "edited_message"],
+            "allowed_updates": ["message", "edited_message", "callback_query"],
             "secret_token": "secret-value",
         }
     ]

--- a/backend_new/tests/test_telegram_webhook.py
+++ b/backend_new/tests/test_telegram_webhook.py
@@ -90,3 +90,45 @@ def test_telegram_webhook_enqueues_update(monkeypatch) -> None:
         assert response.text == "OK"
         assert fake_app.update_queue.qsize() == 1
         delattr(test_app.state, "telegram_runtime")
+
+
+def test_telegram_webhook_enqueues_callback_query(monkeypatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://postgres:password@127.0.0.1:5432/moneytrack")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "secret-value")
+    get_settings.cache_clear()
+
+    fake_app = _FakeApplication(
+        bot=Bot("123456:ABCDEF"),
+        update_queue=asyncio.Queue(),
+    )
+    fake_runtime = _FakeRuntime(application=fake_app, is_enabled=True)
+
+    payload = {
+        "update_id": 2,
+        "callback_query": {
+            "id": "abc123",
+            "from": {"id": 459885395, "is_bot": False, "first_name": "Aleksei"},
+            "chat_instance": "ci1",
+            "data": "cs1:1:1:r:0:sig",
+            "message": {
+                "message_id": 20,
+                "date": 1758301908,
+                "chat": {"id": 459885395, "type": "private"},
+                "text": "Saved",
+            },
+        },
+    }
+
+    test_app = _build_test_app()
+    with TestClient(test_app) as client:
+        test_app.state.telegram_runtime = fake_runtime
+        response = client.post(
+            "/api/telegram/webhook",
+            headers={"X-Telegram-Bot-Api-Secret-Token": "secret-value"},
+            json=payload,
+        )
+        assert response.status_code == 200
+        assert response.text == "OK"
+        assert fake_app.update_queue.qsize() == 1
+        delattr(test_app.state, "telegram_runtime")

--- a/docs/prds/prd-transaction-category-suggestion.md
+++ b/docs/prds/prd-transaction-category-suggestion.md
@@ -60,7 +60,7 @@ We need a two-step enrichment flow that keeps current parsing behavior but adds 
 
 ### FR-4: LLM category proposal
 - Input context includes:
-  - Current transaction: note, amount, currency.
+  - Current transaction: note, sms_text, amount, currency.
   - Similar categorized examples (up to 3 distinct-category rows).
   - Available categories.
 - LLM outputs ranked candidates (1..N), with top-1 required.
@@ -106,6 +106,9 @@ We need a two-step enrichment flow that keeps current parsing behavior but adds 
   - `Category C` (LLM top-3)
   - `Remove category`
 - If fewer than 3 valid LLM suggestions are available, fill remaining category buttons with deterministic fallbacks from available categories (excluding duplicates) so UX always shows 4 buttons.
+  - Fallback ordering rule:
+    - Keep global stable ordering baseline (`order_index`, then `name`).
+    - Prioritize categories whose `type` matches transaction amount sign (`Expense` for negative, `Income` for positive), then append remaining categories in stable order.
 
 ### Callback behavior
 - Secure callback payload should include transaction identifier (compact + signed if possible).
@@ -127,6 +130,7 @@ We need a two-step enrichment flow that keeps current parsing behavior but adds 
   - Exclude current transaction id.
 - Distinct by category (`DISTINCT ON (category_id)` or equivalent Piccolo strategy).
 - Rank by similarity + recency, limit 3.
+  - Implementation should keep category-distinct reduction in DB query (avoid loading large candidate sets and de-duplicating in application memory).
 
 ## Category list query
 - Fetch global categories table (id, name, type).
@@ -230,6 +234,8 @@ Track quality KPI:
 4. Note similarity in v1 uses `ILIKE` prefix search (`'<prefix>%'`) with mandatory `user_id` filter.
 5. Message action buttons (top-3 categories + remove/cancel) use Telegram `callback_data`; backend handles `callback_query` and applies updates server-side (service call in-process, or internal API call if bot/API are split).
 6. Fallback categories (when LLM returns fewer than 3) are filled in stable category order (`order_index`, then `name`).
+7. LLM context includes original `sms_text` in addition to `note`, `amount`, and `currency`.
+8. Fallback category prioritization is sign-aware: for positive amounts prioritize `Income` categories; for negative amounts prioritize `Expense` categories; then append remaining categories in stable order.
 
 ## 19) Out of Scope for This PRD
 

--- a/docs/tasklist.md
+++ b/docs/tasklist.md
@@ -18,6 +18,7 @@ Legend: Pending | In Progress | Complete | Blocked
 | Telegram Flow Migration | `SavingTransactions` flow moved from n8n to FastAPI + PTB webhook ingestion | Complete | 2026-03-20 | Added `/api/telegram/webhook`, PTB runtime, OpenAI parsing, and Telegram ingestion tests |
 | Telegram Reply Formatting | Telegram save confirmation now renders amounts with two decimal places | Complete | 2026-03-23 | Normalized reply text to fixed `.2f` amount formatting for saved transactions |
 | Auto Category Suggestion PRD | Product requirements and rollout definition for two-step LLM category assignment in Telegram ingestion | Complete | 2026-04-03 | Added PRD covering retrieval, LLM ranking, auto-apply, and Telegram remove-category action |
+| Auto Category Suggestion Implementation | Two-step Telegram category suggestion, inline callback actions, signed callback payloads, and real-LLM Telegram e2e coverage | Complete | 2026-04-03 | Added business services, callback handling, observability logs, and gated integration e2e validating auto-assign/override/remove |
 
 ## Working Rules
 


### PR DESCRIPTION
- Added integration tests for SMS parser and Telegram category suggestion.
- Updated SMS parser test cases with new transaction details and expected outputs.
- Created new tests for Telegram category suggestion, including callback handling and category updates.
- Enhanced Telegram ingestion to process callback queries and send appropriate responses.
- Updated PRD to reflect changes in LLM context and fallback category prioritization.
- Added logging redaction tests for sensitive information.
- Implemented callback data encoding/decoding with signature verification.