### PR TITLE
Add webhook diagnostics for Telegram callback button issues

### DIFF
--- a/backend_new/app/api/routes/telegram.py
+++ b/backend_new/app/api/routes/telegram.py
@@ -32,7 +32,12 @@ async def telegram_webhook(
     x_telegram_bot_api_secret_token: str | None = Header(default=None, alias="X-Telegram-Bot-Api-Secret-Token"),
 ) -> PlainTextResponse:
     with tracer.start_as_current_span("telegram.webhook.receive"):
+        logger.info("Telegram webhook request received")
         if not _is_webhook_secret_valid(x_telegram_bot_api_secret_token):
+            logger.error(
+                "Telegram webhook rejected: invalid secret token (header present=%s)",
+                x_telegram_bot_api_secret_token is not None,
+            )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid Telegram webhook secret",
@@ -40,6 +45,7 @@ async def telegram_webhook(
 
         runtime = cast(TelegramBotRuntime | None, getattr(request.app.state, "telegram_runtime", None))
         if runtime is None or not runtime.is_enabled:
+            logger.error("Telegram webhook rejected: runtime is not enabled")
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Telegram runtime is not enabled",
@@ -47,9 +53,11 @@ async def telegram_webhook(
 
         body = await request.json()
         if not isinstance(body, Mapping):
+            logger.error("Telegram webhook rejected: payload is not a JSON object")
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid update payload")
         parsed_update = Update.de_json(dict(body), runtime.application.bot)
         if parsed_update is None:
+            logger.error("Telegram webhook rejected: failed to parse update payload")
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid update payload")
 
         await runtime.application.update_queue.put(parsed_update)


### PR DESCRIPTION
### Motivation
- Make webhook rejection reasons visible in logs so Telegram callback queries that leave the client stuck waiting can be diagnosed when requests never reach the runtime or are rejected by the API.

### Description
- Added diagnostic logging to `backend_new/app/api/routes/telegram.py` including `logger.info("Telegram webhook request received")` and `logger.error(...)` messages for invalid secret header, disabled runtime, non-object payloads, and failed update parsing, while preserving existing behavior that enqueues the parsed `Update` to `runtime.application.update_queue`.

### Testing
- Ran `cd backend_new && uv run pytest -q tests/test_telegram_webhook.py tests/test_telegram_ingestion.py` and the test suite passed (10 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc192534fc83209bdd70521493616c)