### PR TITLE
Fix incorrect parse-failure fallback when Telegram reply send fails

### DIFF
--- a/backend_new/app/services/telegram_ingestion.py
+++ b/backend_new/app/services/telegram_ingestion.py
@@ -74,6 +74,11 @@ def _normalize_message_update(update: Update) -> NormalizedTelegramMessage | Non
 
 
 async def _send_unparsed(bot: Bot, *, chat_id: int, reply_to_message_id: int) -> None:
+    logger.info(
+        "Telegram outgoing reply reply_type=parse_failed_reply chat_id=%s reply_to_message_id=%s",
+        chat_id,
+        reply_to_message_id,
+    )
     await bot.send_message(
         chat_id=chat_id,
         text=UNPARSED_REPLY_TEXT,
@@ -140,6 +145,12 @@ async def _send_create_reply(
         f"Currency: {transaction.currency}\n"
         f"Note: {note}"
     )
+    logger.info(
+        ("Telegram outgoing reply reply_type=success_reply chat_id=%s reply_to_message_id=%s transaction_id=%s"),
+        chat_id,
+        reply_to_message_id,
+        transaction.id,
+    )
     await bot.send_message(
         chat_id=chat_id,
         text=text,
@@ -203,14 +214,27 @@ async def _handle_message_update(
     )
     suggestion = await _resolve_suggestion(normalized=normalized, transaction=created)
 
-    await _send_create_reply(
-        context.bot,
-        chat_id=normalized.chat_id,
-        user_id=normalized.from_id,
-        reply_to_message_id=normalized.message_id,
-        transaction=created,
-        suggestion=suggestion,
-    )
+    try:
+        await _send_create_reply(
+            context.bot,
+            chat_id=normalized.chat_id,
+            user_id=normalized.from_id,
+            reply_to_message_id=normalized.message_id,
+            transaction=created,
+            suggestion=suggestion,
+        )
+    except Exception as exc:
+        logger.error(
+            (
+                "Failed to send Telegram success reply after persisted transaction: %s "
+                "transaction_id=%s user_id=%s chat_id=%s"
+            ),
+            exc,
+            created.id,
+            normalized.from_id,
+            normalized.chat_id,
+            exc_info=True,
+        )
 
 
 async def _handle_callback_query(
@@ -293,18 +317,3 @@ async def handle_telegram_update(update: object, context: ContextTypes.DEFAULT_T
             await _handle_message_update(update=update, context=context)
         except Exception as exc:
             logger.error("Failed to process Telegram update: %s", exc, exc_info=True)
-            normalized = _normalize_message_update(update)
-            if normalized is None:
-                return
-            try:
-                await _send_unparsed(
-                    context.bot,
-                    chat_id=normalized.chat_id,
-                    reply_to_message_id=normalized.message_id,
-                )
-            except Exception as send_exc:
-                logger.error(
-                    "Failed to send fallback Telegram reply: %s",
-                    send_exc,
-                    exc_info=True,
-                )


### PR DESCRIPTION
### Motivation
- Prevent a transport/send failure when replying via Telegram from being surfaced to users as the parse error text `"Cannot parse the transaction"`.
- Ensure successful persistence and category-suggestion paths are not misreported when outbound message delivery times out or fails.
- Improve observability for outgoing replies to simplify future incident triage.

### Description
- Added structured info logs in `_send_unparsed` and `_send_create_reply` to record outgoing reply types (`reply_type=parse_failed_reply` and `reply_type=success_reply`) with `chat_id`, `reply_to_message_id`, and `transaction_id` metadata.
- Wrapped the call to `_send_create_reply` inside `_handle_message_update` with a `try/except` that logs transport/send failures with transaction/user/chat context and does not trigger a parse-failure reply.
- Removed the global fallback behavior in `handle_telegram_update` that attempted to send the parse-failure reply for any unexpected exception, so unrelated errors no longer produce misleading user messages.

### Testing
- Ran formatter: `uv run ruff format app/services/telegram_ingestion.py` and it completed successfully.
- Ran linter/check: `uv run ruff check app/services/telegram_ingestion.py` and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c2356e6b4832093eebc9484e33560)